### PR TITLE
Resolve bug in github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           popd
       - name: Push badge commit
         uses: ad-m/github-push-action@master
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: badges


### PR DESCRIPTION
Prevent pushing badges in github actions for PRs created by forked repos. 