### PR TITLE
Make phone number while creating RootUser optional

### DIFF
--- a/docs/api_reference/Models/RootUser.md
+++ b/docs/api_reference/Models/RootUser.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **username** | **String** |  | [default to null]
 **passwordHash** | **String** |  | [default to null]
 **email** | **String** |  | [default to null]
-**phone** | **String** |  | [default to null]
+**phone** | **String** |  | [optional] [default to null]
 **verified** | **Boolean** |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -2093,7 +2093,6 @@ components:
         - username
         - passwordHash
         - email
-        - phone
         - verified
       properties:
         username:

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -90,7 +90,8 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
                     credentials = PasswordCredentials(
                         userName = rootUser.username,
                         email = rootUser.email,
-                        phoneNumber = rootUser.phone, password = rootUser.passwordHash
+                        phoneNumber = rootUser.phone ?: "",
+                        password = rootUser.passwordHash
                     ),
                     createdBy = "iam-system",
                     verified = rootUser.verified ?: false

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -238,7 +238,7 @@ val rootUserRequestValidation = Validation<RootUser> {
     RootUser::username required {
         run(userNameCheck)
     }
-    RootUser::phone required {
+    RootUser::phone ifPresent {
         run(phoneNumberCheck)
     }
     RootUser::email required {

--- a/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
@@ -39,7 +39,7 @@ class ExceptionHandlerTest : AbstractContainerBaseTest() {
 
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, testPassword, testEmail, testPhone, true)
+                RootUser(userName, testPassword, testEmail, true, testPhone)
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {

--- a/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
@@ -47,14 +47,13 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             val orgName = "test-org" + IdGenerator.randomId()
             val userName = "test-user" + IdGenerator.randomId()
             val testEmail = "test-user-email" + IdGenerator.randomId() + "@hypto.in"
-            val testPhone = "+919626012778"
             val testPassword = "testPassword@Hash1"
             val verified = true
 
             lateinit var orgId: String
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, testPassword, testEmail, testPhone, verified)
+                RootUser(userName, testPassword, testEmail, verified)
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -102,7 +101,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                         gson.toJson(
                             CreateOrganizationRequest(
                                 orgName,
-                                RootUser(userName, testPassword, testEmail, testPhone, true)
+                                RootUser(userName, testPassword, testEmail, true, testPhone)
                             )
                         )
                     )
@@ -138,7 +137,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             }
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, testPassword, testEmail, testPhone, verified)
+                RootUser(userName, testPassword, testEmail, verified, testPhone)
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -183,7 +182,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
 
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, testPassword, testEmail, testPhone, true)
+                RootUser(userName, testPassword, testEmail, true, testPhone)
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -216,7 +215,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, testPassword, testEmail, testPhone, true)
+                            RootUser(userName, testPassword, testEmail, true, testPhone)
                         )
                     )
                 )
@@ -256,7 +255,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, testPassword, testEmail, testPhone, true)
+                            RootUser(userName, testPassword, testEmail, true, testPhone)
                         )
                     )
                 )
@@ -299,7 +298,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, testPassword, testEmail, testPhone, true)
+                            RootUser(userName, testPassword, testEmail, true, testPhone)
                         )
                     )
                 )
@@ -342,7 +341,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, testPassword, testEmail, testPhone, true),
+                            RootUser(userName, testPassword, testEmail, true, testPhone),
                             orgDescription
                         )
                     )


### PR DESCRIPTION
We are having phone number optional while creating user
https://github.com/hwslabs/iam/blob/7494356fe827e8027fbdf210bdb3eeea77ebb171/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt#L361-L365
But while creating RootUser we have phone number as a required field.