### PR TITLE
Change withPermission to accept getResourceHrn function

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -2,44 +2,12 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ConstructorParameterNaming:ActionPaginatedResponse.kt$ActionPaginatedResponse$val `data`: kotlin.collections.List&lt;Action&gt;? = null</ID>
-    <ID>ConstructorParameterNaming:PolicyPaginatedResponse.kt$PolicyPaginatedResponse$val `data`: kotlin.collections.List&lt;Policy&gt;? = null</ID>
-    <ID>ConstructorParameterNaming:ResourcePaginatedResponse.kt$ResourcePaginatedResponse$val `data`: kotlin.collections.List&lt;Resource&gt;? = null</ID>
-    <ID>ConstructorParameterNaming:UserPaginatedResponse.kt$UserPaginatedResponse$val `data`: kotlin.collections.List&lt;User&gt;? = null</ID>
-    <ID>EnumNaming:CreateUserRequest.kt$CreateUserRequest.Status.disabled$disabled</ID>
-    <ID>EnumNaming:CreateUserRequest.kt$CreateUserRequest.Status.enabled$enabled</ID>
-    <ID>EnumNaming:Credential.kt$Credential.Status.active$active</ID>
-    <ID>EnumNaming:Credential.kt$Credential.Status.inactive$inactive</ID>
-    <ID>EnumNaming:CredentialWithoutSecret.kt$CredentialWithoutSecret.Status.active$active</ID>
-    <ID>EnumNaming:CredentialWithoutSecret.kt$CredentialWithoutSecret.Status.inactive$inactive</ID>
-    <ID>EnumNaming:KeyResponse.kt$KeyResponse.Format.der$der</ID>
-    <ID>EnumNaming:KeyResponse.kt$KeyResponse.Format.pem$pem</ID>
-    <ID>EnumNaming:PaginationOptions.kt$PaginationOptions.SortOrder.asc$asc</ID>
-    <ID>EnumNaming:PaginationOptions.kt$PaginationOptions.SortOrder.desc$desc</ID>
-    <ID>EnumNaming:PolicyStatement.kt$PolicyStatement.Effect.allow$allow</ID>
-    <ID>EnumNaming:PolicyStatement.kt$PolicyStatement.Effect.deny$deny</ID>
-    <ID>EnumNaming:ResourceActionEffect.kt$ResourceActionEffect.Effect.allow$allow</ID>
-    <ID>EnumNaming:ResourceActionEffect.kt$ResourceActionEffect.Effect.deny$deny</ID>
-    <ID>EnumNaming:UpdateCredentialRequest.kt$UpdateCredentialRequest.Status.active$active</ID>
-    <ID>EnumNaming:UpdateCredentialRequest.kt$UpdateCredentialRequest.Status.inactive$inactive</ID>
-    <ID>EnumNaming:UpdateUserRequest.kt$UpdateUserRequest.Status.disabled$disabled</ID>
-    <ID>EnumNaming:UpdateUserRequest.kt$UpdateUserRequest.Status.enabled$enabled</ID>
-    <ID>EnumNaming:User.kt$User.Status.disabled$disabled</ID>
-    <ID>EnumNaming:User.kt$User.Status.enabled$enabled</ID>
-    <ID>EnumNaming:VerifyEmailRequest.kt$VerifyEmailRequest.Purpose.reset$reset</ID>
-    <ID>EnumNaming:VerifyEmailRequest.kt$VerifyEmailRequest.Purpose.signup$signup</ID>
+    <ID>LongParameterList:DataSetupHelper.kt$DataSetupHelper$( orgId: String, bearerToken: String, policyName: String, accountId: String?, resourceName: String, actionName: String, resourceInstance: String, engine: TestApplicationEngine, effect: PolicyStatement.Effect = PolicyStatement.Effect.allow )</ID>
     <ID>MagicNumber:Configuration.kt$10.0</ID>
     <ID>MagicNumber:Configuration.kt$1024</ID>
     <ID>MagicNumber:Configuration.kt$365</ID>
-    <ID>MagicNumber:Configuration.kt$4</ID>
     <ID>MagicNumber:Configuration.kt$60</ID>
-    <ID>MaxLineLength:Configuration.kt$MicrometerConfigs$/* * TODO: Configure "LoggingMeterRegistry" with a logging sink to direct metrics logs to a separate "iam_metrics.log" logback appender * http://javadox.com/io.micrometer/micrometer-core/1.2.1/io/micrometer/core/instrument/logging/LoggingMeterRegistry.Builder.html#loggingSink(java.util.function.Consumer) */</ID>
     <ID>MaxLineLength:Hrn.kt$Hrn$*</ID>
-    <ID>MaxLineLength:Hrn.kt$ResourceHrn$// 5. /organization/&lt;organizationId&gt;/resource/&lt;resourceId&gt; - hrn:hypto:&lt;accountId&gt;:iam-resource/12345 - updateResource</ID>
-    <ID>MaxLineLength:Hrn.kt$ResourceHrn$// 6. /organization/&lt;organizationId&gt;/user/&lt;userId&gt;/credentials/ - hrn:hypto:&lt;accountId&gt;:iam-user/12345 - addCredentials</ID>
-    <ID>MaxLineLength:Hrn.kt$ResourceHrn$// 7. /organization/&lt;organizationId&gt;/resource/&lt;resourceId&gt;/action/ - hrn:hypto:&lt;accountId&gt;:iam-resource/12345 - addAction</ID>
-    <ID>MaxLineLength:Hrn.kt$ResourceHrn$// 8. /organization/&lt;organizationId&gt;/user/&lt;userId&gt;/credentials/&lt;credentialsId&gt; - hrn:hypto:&lt;accountId&gt;:iam-credential/12345 - getCredentials</ID>
-    <ID>MaxLineLength:Hrn.kt$ResourceHrn$// 9. /organization/&lt;organizationId&gt;/resource/&lt;resourceId&gt;/action/&lt;actionId&gt; - hrn:hypto:&lt;accountId&gt;:iam-action/12345 - updateAction</ID>
     <ID>MaxLineLength:Hrn.kt$ResourceHrn.Companion$"""^hrn:(?&lt;organization&gt;[^:\n]+):(?&lt;accountId&gt;[^:\n]*):(?&lt;resource&gt;[^:/\n]*)/{0,1}(?&lt;resourceInstance&gt;[^/\n:]*)""".toRegex()</ID>
     <ID>ThrowsCount:ResourceApi.kt$fun Route.resourceApi()</ID>
     <ID>TooGenericExceptionThrown:AuditEventHandler.kt$AuditEventHandler$throw Exception("few Batch inserts failed")</ID>

--- a/src/main/kotlin/com/hypto/iam/server/apis/ActionApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/ActionApi.kt
@@ -5,6 +5,7 @@ import com.hypto.iam.server.extensions.PaginationContext
 import com.hypto.iam.server.models.CreateActionRequest
 import com.hypto.iam.server.models.PaginationOptions
 import com.hypto.iam.server.models.UpdateActionRequest
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.ActionService
 import com.hypto.iam.server.validators.validate
@@ -24,7 +25,10 @@ fun Route.actionApi() {
     val actionService: ActionService by inject()
     val gson: Gson by inject()
 
-    withPermission("createAction") {
+    withPermission(
+        "createAction",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         post("/organizations/{organization_id}/resources/{resource_name}/actions") {
             val organizationId = call.parameters["organization_id"]
             val resourceName = call.parameters["resource_name"]
@@ -41,7 +45,10 @@ fun Route.actionApi() {
         }
     }
 
-    withPermission("listAction") {
+    withPermission(
+        "listAction",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/resources/{resource_name}/actions") {
             val organizationId = call.parameters["organization_id"]
             val resourceName = call.parameters["resource_name"]
@@ -65,7 +72,10 @@ fun Route.actionApi() {
         }
     }
 
-    withPermission("getAction") {
+    withPermission(
+        "getAction",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/resources/{resource_name}/actions/{action_name}") {
             val organizationId = call.parameters["organization_id"]
             val resourceName = call.parameters["resource_name"]
@@ -81,7 +91,10 @@ fun Route.actionApi() {
         }
     }
 
-    withPermission("updateAction") {
+    withPermission(
+        "updateAction",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/resources/{resource_name}/actions/{action_name}") {
             val organizationId = call.parameters["organization_id"]
             val resourceName = call.parameters["resource_name"]
@@ -99,7 +112,10 @@ fun Route.actionApi() {
         }
     }
 
-    withPermission("deleteAction") {
+    withPermission(
+        "deleteAction",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         delete("/organizations/{organization_id}/resources/{resource_name}/actions/{action_name}") {
             val organizationId = call.parameters["organization_id"]
             val resourceName = call.parameters["resource_name"]

--- a/src/main/kotlin/com/hypto/iam/server/apis/CredentialApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/CredentialApi.kt
@@ -5,6 +5,7 @@ package com.hypto.iam.server.apis
 import com.google.gson.Gson
 import com.hypto.iam.server.models.CreateCredentialRequest
 import com.hypto.iam.server.models.UpdateCredentialRequest
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.CredentialService
 import com.hypto.iam.server.validators.validate
@@ -25,7 +26,10 @@ fun Route.credentialApi() {
     val gson: Gson by inject()
     val credentialService: CredentialService by inject()
 
-    withPermission("createCredential") {
+    withPermission(
+        "createCredential",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         post("/organizations/{organization_id}/users/{userId}/credentials") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -42,7 +46,10 @@ fun Route.credentialApi() {
         }
     }
 
-    withPermission("deleteCredential") {
+    withPermission(
+        "deleteCredential",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         delete("/organizations/{organization_id}/users/{userId}/credentials/{id}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -59,7 +66,10 @@ fun Route.credentialApi() {
         }
     }
 
-    withPermission("getCredential") {
+    withPermission(
+        "getCredential",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/users/{userId}/credentials/{id}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -76,7 +86,10 @@ fun Route.credentialApi() {
         }
     }
 
-    withPermission("listCredential") {
+    withPermission(
+        "listCredential",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/users/{userId}/credentials") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["userId"]!!
@@ -91,7 +104,10 @@ fun Route.credentialApi() {
         }
     }
 
-    withPermission("updateCredential") {
+    withPermission(
+        "updateCredential",
+        getResourceHrnFunc(resourceNameIndex = 4, resourceInstanceIndex = 5, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/users/{userId}/credentials/{id}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")

--- a/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
@@ -5,6 +5,7 @@ import com.hypto.iam.server.models.CreateOrganizationRequest
 import com.hypto.iam.server.models.CreateOrganizationResponse
 import com.hypto.iam.server.models.UpdateOrganizationRequest
 import com.hypto.iam.server.security.ApiPrincipal
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.OrganizationsService
 import com.hypto.iam.server.validators.validate
@@ -77,7 +78,10 @@ fun Route.getAndUpdateOrganizationApi() {
     val gson: Gson by inject()
 
     route("/organizations/{id}") {
-        withPermission("getOrganization") {
+        withPermission(
+            "getOrganization",
+            getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+        ) {
             get {
                 val id = call.parameters["id"]!!
                 val response = service.getOrganization(id)
@@ -89,7 +93,10 @@ fun Route.getAndUpdateOrganizationApi() {
             }
         }
 
-        withPermission("updateOrganization") {
+        withPermission(
+            "updateOrganization",
+            getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+        ) {
             patch {
                 val id = call.parameters["id"]!!
                 val request = call.receive<UpdateOrganizationRequest>().validate()

--- a/src/main/kotlin/com/hypto/iam/server/apis/PolicyApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/PolicyApi.kt
@@ -9,6 +9,7 @@ import com.hypto.iam.server.models.PaginationOptions
 import com.hypto.iam.server.models.UpdatePolicyRequest
 import com.hypto.iam.server.security.AuthorizationException
 import com.hypto.iam.server.security.UserPrincipal
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.PolicyService
 import com.hypto.iam.server.validators.validate
@@ -30,7 +31,10 @@ fun Route.policyApi() {
     val policyService: PolicyService by inject()
     val gson: Gson by inject()
 
-    withPermission("createPolicy") {
+    withPermission(
+        "createPolicy",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         post("/organizations/{organization_id}/policies") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -51,7 +55,10 @@ fun Route.policyApi() {
         }
     }
 
-    withPermission("listPolicy") {
+    withPermission(
+        "listPolicy",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/policies") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("Required organization_id to get user")
@@ -75,7 +82,10 @@ fun Route.policyApi() {
         }
     }
 
-    withPermission("deletePolicy") {
+    withPermission(
+        "deletePolicy",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         delete("/organizations/{organization_id}/policies/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -91,7 +101,10 @@ fun Route.policyApi() {
         }
     }
 
-    withPermission("getPolicy") {
+    withPermission(
+        "getPolicy",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/policies/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -108,7 +121,10 @@ fun Route.policyApi() {
         }
     }
 
-    withPermission("getUserPolicy") {
+    withPermission(
+        "getUserPolicy",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/users/{user_id}/policies") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -135,7 +151,10 @@ fun Route.policyApi() {
         }
     }
 
-    withPermission("updatePolicy") {
+    withPermission(
+        "updatePolicy",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/policies/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")

--- a/src/main/kotlin/com/hypto/iam/server/apis/ResourceApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/ResourceApi.kt
@@ -5,6 +5,7 @@ import com.hypto.iam.server.extensions.PaginationContext
 import com.hypto.iam.server.models.CreateResourceRequest
 import com.hypto.iam.server.models.PaginationOptions
 import com.hypto.iam.server.models.UpdateResourceRequest
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.ResourceService
 import com.hypto.iam.server.validators.validate
@@ -25,7 +26,10 @@ fun Route.resourceApi() {
     val resourceService: ResourceService by inject()
     val gson: Gson by inject()
 
-    withPermission("createResource") {
+    withPermission(
+        "createResource",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         post("/organizations/{organization_id}/resources") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -41,7 +45,10 @@ fun Route.resourceApi() {
         }
     }
 
-    withPermission("listResource") {
+    withPermission(
+        "listResource",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/resources") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("Required organization_id to get user")
@@ -65,7 +72,10 @@ fun Route.resourceApi() {
         }
     }
 
-    withPermission("deletePermission") {
+    withPermission(
+        "deletePermission",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         delete("/organizations/{organization_id}/resources/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -81,7 +91,10 @@ fun Route.resourceApi() {
         }
     }
 
-    withPermission("getResource") {
+    withPermission(
+        "getResource",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/resources/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")
@@ -97,7 +110,10 @@ fun Route.resourceApi() {
         }
     }
 
-    withPermission("updateResource") {
+    withPermission(
+        "updateResource",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/resources/{name}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("organization_id required")

--- a/src/main/kotlin/com/hypto/iam/server/apis/UsersApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UsersApi.kt
@@ -10,6 +10,7 @@ import com.hypto.iam.server.models.ResetPasswordRequest
 import com.hypto.iam.server.models.UpdateUserRequest
 import com.hypto.iam.server.models.UserPaginatedResponse
 import com.hypto.iam.server.security.UserPrincipal
+import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.UserPolicyService
 import com.hypto.iam.server.service.UsersService
@@ -39,7 +40,10 @@ fun Route.usersApi() {
     // **** User management apis ****//
 
     // Create user
-    withPermission("createUser") {
+    withPermission(
+        "createUser",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         post("/organizations/{organization_id}/users") {
             val organizationId = call.parameters["organization_id"]!!
             val request = call.receive<CreateUserRequest>().validate()
@@ -62,7 +66,10 @@ fun Route.usersApi() {
     }
 
     // Get user
-    withPermission("getUser") {
+    withPermission(
+        "getUser",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/users/{id}") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["id"]!!
@@ -76,7 +83,10 @@ fun Route.usersApi() {
     }
 
     // List user
-    withPermission("listUser") {
+    withPermission(
+        "listUser",
+        getResourceHrnFunc(resourceNameIndex = 0, resourceInstanceIndex = 1, organizationIdIndex = 1)
+    ) {
         get("/organizations/{organization_id}/users") {
             val organizationId = call.parameters["organization_id"]!!
             val nextToken = call.request.queryParameters["next_token"]
@@ -92,7 +102,10 @@ fun Route.usersApi() {
     }
 
     // Delete user
-    withPermission("deleteUser") {
+    withPermission(
+        "deleteUser",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         delete("/organizations/{organization_id}/users/{user_id}") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["user_id"]!!
@@ -106,7 +119,10 @@ fun Route.usersApi() {
     }
 
     // Update user
-    withPermission("updateUser") {
+    withPermission(
+        "updateUser",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/users/{user_id}") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("Required organization_id to update user")
@@ -131,7 +147,10 @@ fun Route.usersApi() {
     // **** User policy management apis ****//
 
     // Detach policy
-    withPermission("detachPolicies") {
+    withPermission(
+        "detachPolicies",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/users/{user_id}/detach_policies") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("Required organization_id to detach policies")
@@ -151,7 +170,10 @@ fun Route.usersApi() {
     }
 
     // Attach policy
-    withPermission("attachPolicies") {
+    withPermission(
+        "attachPolicies",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
         patch("/organizations/{organization_id}/users/{user_id}/attach_policies") {
             val organizationId = call.parameters["organization_id"]
                 ?: throw IllegalArgumentException("Required organization_id to attach policies")

--- a/src/main/kotlin/com/hypto/iam/server/utils/IamResources.kt
+++ b/src/main/kotlin/com/hypto/iam/server/utils/IamResources.kt
@@ -5,5 +5,19 @@ object IamResources {
     const val ACCOUNT = "iam-account"
     const val USER = "iam-user"
     const val POLICY = "iam-policy"
+    const val RESOURCE = "iam-resource"
     const val ROLE = "iam-role"
+    const val ACTION = "iam-action"
+    const val CREDENTIAL = "iam-credential"
+
+    val resourceMap: Map<String, String> = mapOf(
+        "users" to USER,
+        "resources" to RESOURCE,
+        "policies" to POLICY,
+        "actions" to ACTION,
+        "credentials" to CREDENTIAL,
+        "roles" to ROLE,
+        "organizations" to ORGANIZATION,
+        "accounts" to ACCOUNT
+    )
 }


### PR DESCRIPTION
Now `getResourceHrn` function will define how to create a `ResourceHrn` out of a `ApplicationRequest`.
In future, we can have custom Apis with custom url patterns, it might get hard to parse `resourceName` and `resourceInstanceId` using a single parsing logic.

The urls that were not able to parsed correctly as of now:
1. `/organizations/{organization_id}/users/{user_name}/attach_policies:`
2. `/organizations/{organization_id}/users/{user_name}/detach_policies:`
