### PR TITLE
Root user name is made optional during signup.

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -2224,7 +2224,6 @@ components:
       additionalProperties: false
       required:
         - username
-        - name
         - passwordHash
         - email
         - verified

--- a/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
+++ b/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
@@ -279,9 +279,11 @@ class CognitoIdentityProviderImpl : IdentityProvider, KoinComponent {
         identityGroup: IdentityGroup,
         credentials: PasswordCredentials
     ): User {
-        val nameAttr = AttributeType.builder()
-            .name(ATTRIBUTE_NAME)
-            .value(credentials.name).build()
+        val nameAttr = credentials.name?.let {
+            AttributeType.builder()
+                .name(ATTRIBUTE_NAME)
+                .value(credentials.name).build()
+        }
         val emailAttr = AttributeType.builder()
             .name(ATTRIBUTE_EMAIL)
             .value(credentials.email).build()
@@ -300,7 +302,12 @@ class CognitoIdentityProviderImpl : IdentityProvider, KoinComponent {
             .userPoolId(identityGroup.id)
             .username(credentials.userName)
             .temporaryPassword(credentials.password)
-            .userAttributes(nameAttr, emailAttr, emailVerifiedAttr, phoneNumberAttr, createdBy)
+            .apply {
+                if (nameAttr == null)
+                    userAttributes(emailAttr, emailVerifiedAttr, phoneNumberAttr, createdBy)
+                else
+                    userAttributes(nameAttr, emailAttr, emailVerifiedAttr, phoneNumberAttr, createdBy)
+            }
             .messageAction(ACTION_SUPPRESS) // TODO: Make welcome email as configuration option
             .build()
         val adminCreateUserResponse = cognitoClient.adminCreateUser(userRequest)

--- a/src/main/kotlin/com/hypto/iam/server/idp/IdentityProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/idp/IdentityProvider.kt
@@ -70,7 +70,7 @@ abstract class UserCredentials {
 
 data class PasswordCredentials(
     override val userName: String,
-    val name: String,
+    val name: String?,
     val email: String,
     val phoneNumber: String,
     val password: String

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -247,11 +247,11 @@ val passwordCheck = Validation<String> {
     minLength(Constants.MINIMUM_PASSWORD_LENGTH) hint "Minimum length expected is ${Constants.MINIMUM_PASSWORD_LENGTH}"
     pattern(PASSWORD_REGEX) hint PASSWORD_REGEX_HINT
 }
-val rootUserRequestValidation = Validation<RootUser> {
+val rootUserRequestValidation = Validation {
     RootUser::username required {
         run(userNameCheck)
     }
-    RootUser::name required {
+    RootUser::name ifPresent {
         run(nameOfUserCheck)
     }
     RootUser::phone ifPresent {

--- a/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
@@ -41,7 +41,14 @@ class ExceptionHandlerTest : AbstractContainerBaseTest() {
 
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                RootUser(
+                    username = userName,
+                    name = name,
+                    passwordHash = testPassword,
+                    verified = true,
+                    email = testEmail,
+                    phone = testPhone
+                )
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {

--- a/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
@@ -55,7 +55,13 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             lateinit var orgId: String
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, name, testPassword, testEmail, verified)
+                RootUser(
+                    username = userName,
+                    name = name,
+                    passwordHash = testPassword,
+                    email = testEmail,
+                    verified = verified
+                )
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -82,9 +88,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
         declareMock<PasscodeRepo> {
             coEvery {
                 getValidPasscode(
-                    any<String>(),
-                    any<VerifyEmailRequest.Purpose>(),
-                    any<String>()
+                    any<String>(), any<VerifyEmailRequest.Purpose>(), any<String>()
                 )
             } returns null
         }
@@ -104,7 +108,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                         gson.toJson(
                             CreateOrganizationRequest(
                                 orgName,
-                                RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                                RootUser(
+                                    username = userName,
+                                    name = name,
+                                    passwordHash = testPassword,
+                                    email = testEmail,
+                                    phone = testPhone,
+                                    verified = true
+                                )
                             )
                         )
                     )
@@ -132,8 +143,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
 
             lateinit var orgId: String
             val verifyRequestBody = VerifyEmailRequest(
-                email = testEmail,
-                purpose = VerifyEmailRequest.Purpose.signup
+                email = testEmail, purpose = VerifyEmailRequest.Purpose.signup
             )
             handleRequest(HttpMethod.Post, "/verifyEmail") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -141,7 +151,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             }
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, name, testPassword, testEmail, verified, testPhone)
+                RootUser(
+                    username = userName,
+                    name = name,
+                    passwordHash = testPassword,
+                    email = testEmail,
+                    phone = testPhone,
+                    verified = true
+                )
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -150,12 +167,10 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     setBody(gson.toJson(requestBody))
                 }
             ) {
-                val responseBody =
-                    gson.fromJson(response.content, CreateOrganizationResponse::class.java)
+                val responseBody = gson.fromJson(response.content, CreateOrganizationResponse::class.java)
                 assertEquals(HttpStatusCode.Created, response.status())
                 assertEquals(
-                    ContentType.Application.Json.withCharset(UTF_8),
-                    response.contentType()
+                    ContentType.Application.Json.withCharset(UTF_8), response.contentType()
                 )
 
                 orgId = responseBody.organization!!.id
@@ -170,8 +185,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
     @Test
     fun `create organization - rollback on error`() {
 
-        @Suppress("TooGenericExceptionThrown")
-        declareMock<OrganizationRepo> {
+        @Suppress("TooGenericExceptionThrown") declareMock<OrganizationRepo> {
             coEvery { this@declareMock.insert(any<Organizations>()) } coAnswers {
                 throw Exception("Random DB error occurred")
             }
@@ -187,7 +201,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
 
             val requestBody = CreateOrganizationRequest(
                 orgName,
-                RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                RootUser(
+                    username = userName,
+                    name = name,
+                    passwordHash = testPassword,
+                    email = testEmail,
+                    phone = testPhone,
+                    verified = true
+                )
             )
             with(
                 handleRequest(HttpMethod.Post, "/organizations") {
@@ -221,7 +242,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                            RootUser(
+                                username = userName,
+                                name = name,
+                                passwordHash = testPassword,
+                                email = testEmail,
+                                phone = testPhone,
+                                verified = true
+                            )
                         )
                     )
                 )
@@ -262,7 +290,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                            RootUser(
+                                username = userName,
+                                name = name,
+                                passwordHash = testPassword,
+                                email = testEmail,
+                                phone = testPhone,
+                                verified = true
+                            )
                         )
                     )
                 )
@@ -306,7 +341,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, name, testPassword, testEmail, true, testPhone)
+                            RootUser(
+                                username = userName,
+                                name = name,
+                                passwordHash = testPassword,
+                                email = testEmail,
+                                phone = testPhone,
+                                verified = true
+                            )
                         )
                     )
                 )
@@ -318,8 +360,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                 handleRequest(HttpMethod.Get, "/organizations/inValidOrganizationId") {
                     addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     addHeader(
-                        HttpHeaders.Authorization,
-                        "Bearer ${createdOrganization.rootUserToken}"
+                        HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}"
                     )
                 }
 
@@ -350,7 +391,14 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     gson.toJson(
                         CreateOrganizationRequest(
                             orgName,
-                            RootUser(userName, name, testPassword, testEmail, true, testPhone),
+                            RootUser(
+                                username = userName,
+                                name = name,
+                                passwordHash = testPassword,
+                                email = testEmail,
+                                phone = testPhone,
+                                verified = true
+                            ),
                             orgDescription
                         )
                     )


### PR DESCRIPTION
Problem:
To reduce the friction during sign-up, made root user's name as a
optional parameter and the user can update the name by calling
updateUser API once after the user creation.

Test:
Verified by sign-up without and with root user's name attribute.