### PR TITLE
Remove verified from create org request

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -1262,7 +1262,7 @@ components:
   requestBodies:
     CreateOrganizationRequest:
       description: Payload to create organization
-      required: true
+      required: false
       content:
         application/json:
           schema:
@@ -1822,7 +1822,6 @@ components:
           passwordHash: <password>
           email: root@example.com
           phone: "+1234567890"
-          verified: true
 
     UpdateOrganizationRequest:
       summary: A sample UpdateOrganizationRequest
@@ -1951,7 +1950,6 @@ components:
           name: ACME Enterprise
           description: Brief description about ACME
           rootUserPasswordHash: Password@123
-          rootUserVerified: true
           rootUserName: Lorem Ipsum
           rootUserPreferredUsername: username
           rootUserPhone: "+1234567890"
@@ -1972,7 +1970,6 @@ components:
             organizationId: XlK5h64gND
             email: bob@acme.com
             status: enabled
-            verified: true
             phone: "+1234071628"
             loginAccess: true
             createdBy: ''
@@ -2095,7 +2092,6 @@ components:
           organizationId: XlK5h64gND
           email: bob@acme.com
           status: enabled
-          verified: true
           phone: "+1234071628"
           loginAccess: true
           createdBy: ""
@@ -2257,7 +2253,6 @@ components:
         - username
         - passwordHash
         - email
-        - verified
       properties:
         preferredUsername:
           type: string
@@ -2276,8 +2271,6 @@ components:
         phone:
           type: string
           maxLength: 30
-        verified:
-          type: boolean
 
 
     CreateUserRequest:
@@ -2521,10 +2514,9 @@ components:
                 1. name : string (required): name of the organization
                 2. description : string (optional) - description of the organization
                 3. rootUserPasswordHash : string (required) - password of the root user
-                4. rootUserVerified : boolean (required) - if the root user is verified
-                5. rootUserName : string (optional) - name of the root user
-                6. rootUserPreferredUsername : string (optional) - preferred username of the root user
-                7. rootUserPhone : string (optional) - phone number of the root user
+                4. rootUserName : string (optional) - name of the root user
+                5. rootUserPreferredUsername : string (optional) - preferred username of the root user
+                6. rootUserPhone : string (optional) - phone number of the root user
           additionalProperties: true
 
     # Responses:

--- a/src/main/kotlin/com/hypto/iam/server/extensions/Mappers.kt
+++ b/src/main/kotlin/com/hypto/iam/server/extensions/Mappers.kt
@@ -218,10 +218,9 @@ fun CreateOrganizationRequest.Companion.from(
         rootUser = RootUser(
             passwordHash = verifyEmailMetadata["rootUserPasswordHash"] as String,
             email = rootUserEmail,
-            verified = verifyEmailMetadata["rootUserVerified"] as Boolean,
             name = verifyEmailMetadata["rootUserName"] as String?,
             preferredUsername = verifyEmailMetadata["rootUserPreferredUsername"] as String?,
-            phone = verifyEmailMetadata["rootUserPhone"] as String?,
+            phone = verifyEmailMetadata["rootUserPhone"] as String?
         )
     )
 }

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -85,7 +85,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
                         password = rootUser.passwordHash
                     ),
                     createdBy = "iam-system",
-                    verified = rootUser.verified
+                    verified = true
                 )
 
                 // TODO: Avoid this duplicate call be returning the created organization from `organizationRepo.insert`

--- a/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/ExceptionHandlerTest.kt
@@ -45,7 +45,6 @@ class ExceptionHandlerTest : AbstractContainerBaseTest() {
                     preferredUsername = preferredUsername,
                     name = name,
                     passwordHash = testPassword,
-                    verified = true,
                     email = testEmail,
                     phone = testPhone
                 )

--- a/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
@@ -54,7 +54,6 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             val name = "test-name" + IdGenerator.randomId()
             val testEmail = "test-user-email" + IdGenerator.randomId() + "@hypto.in"
             val testPassword = "testPassword@Hash1"
-            val verified = true
 
             lateinit var orgId: String
             val requestBody = CreateOrganizationRequest(
@@ -63,8 +62,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     preferredUsername = preferredUsername,
                     name = name,
                     passwordHash = testPassword,
-                    email = testEmail,
-                    verified = verified
+                    email = testEmail
                 )
             )
             with(
@@ -117,8 +115,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                                     name = name,
                                     passwordHash = testPassword,
                                     email = testEmail,
-                                    phone = testPhone,
-                                    verified = true
+                                    phone = testPhone
                                 )
                             )
                         )
@@ -143,7 +140,6 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
             val testPhone = "+919626012778"
             val testPassword = "testPassword@Hash1"
             val testPasscode = "testPasscode"
-            val verified = true
 
             lateinit var orgId: String
             val verifyRequestBody = VerifyEmailRequest(
@@ -160,8 +156,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     name = name,
                     passwordHash = testPassword,
                     email = testEmail,
-                    phone = testPhone,
-                    verified = true
+                    phone = testPhone
                 )
             )
             with(
@@ -272,8 +267,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                     name = name,
                     passwordHash = testPassword,
                     email = testEmail,
-                    phone = testPhone,
-                    verified = true
+                    phone = testPhone
                 )
             )
             with(
@@ -313,8 +307,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                                 name = name,
                                 passwordHash = testPassword,
                                 email = testEmail,
-                                phone = testPhone,
-                                verified = true
+                                phone = testPhone
                             )
                         )
                     )
@@ -361,8 +354,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                                 name = name,
                                 passwordHash = testPassword,
                                 email = testEmail,
-                                phone = testPhone,
-                                verified = true
+                                phone = testPhone
                             )
                         )
                     )
@@ -412,8 +404,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                                 name = name,
                                 passwordHash = testPassword,
                                 email = testEmail,
-                                phone = testPhone,
-                                verified = true
+                                phone = testPhone
                             )
                         )
                     )
@@ -462,8 +453,7 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                                 name = name,
                                 passwordHash = testPassword,
                                 email = testEmail,
-                                phone = testPhone,
-                                verified = true
+                                phone = testPhone
                             ),
                             orgDescription
                         )

--- a/src/test/kotlin/com/hypto/iam/server/helpers/DataSetupHelper.kt
+++ b/src/test/kotlin/com/hypto/iam/server/helpers/DataSetupHelper.kt
@@ -67,8 +67,7 @@ object DataSetupHelper : AutoCloseKoinTest() {
                 name = name,
                 passwordHash = testPassword,
                 email = testEmail,
-                phone = testPhone,
-                verified = true
+                phone = testPhone
             )
 
             val createOrganizationCall = handleRequest(HttpMethod.Post, "/organizations") {


### PR DESCRIPTION
The verified property of the root user in the create-org request is removed because it will always be true as the root user email is always confirmed for org formation.