### PR TITLE
Password expiring in 7 days after reset password

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
+++ b/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
@@ -291,7 +291,11 @@ class CognitoIdentityProviderImpl : IdentityProvider, KoinComponent {
     ) {
         require(identityGroup.identitySource == IdentityProvider.IdentitySource.AWS_COGNITO)
         val setPasswordRequest =
-            AdminSetUserPasswordRequest.builder().password(password).userPoolId(identityGroup.id).username(userName)
+            AdminSetUserPasswordRequest.builder()
+                .password(password)
+                .permanent(true)
+                .userPoolId(identityGroup.id)
+                .username(userName)
                 .build()
         cognitoClient.adminSetUserPassword(setPasswordRequest)
     }


### PR DESCRIPTION
Desc -
Cognito by default sets the expiry of password to 7 days when admin sets password. Made changes to explicitly request the new password as permanent.

Test -
Verified in a staging aws acc