### PR TITLE
Support to generate delegate token

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -1045,6 +1045,32 @@ paths:
         - basicAuth: [ ]
         - bearerAuth: [ ]
 
+  /delegate_token:
+    post:
+      tags:
+        - User Authorization
+      summary: Generate a delegate token
+      description: Generate a token with ad-hoc principal on behalf of an user with permissions to a policy to which the user has delegate rights.
+      operationId: getDelegateToken
+      requestBody:
+        $ref: '#/components/requestBodies/GetDelegateTokenRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/TokenResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - basicAuth: [ ]
+        - bearerAuth: [ ]
+
   /authenticate:
     post:
       tags:
@@ -1501,6 +1527,16 @@ components:
               $ref: '#/components/examples/VerifyEmailRequestSignup'
             VerifyEmailRequestSignupWithMetadata:
               $ref: '#/components/examples/VerifyEmailRequestSignupWithMetadata'
+    GetDelegateTokenRequest:
+      description: Payload to generate a delegate-able token
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetDelegateTokenRequest'
+          examples:
+            GetDelegateTokenRequest:
+              $ref: '#/components/examples/GetDelegateTokenRequest'
 
   responses:
     BaseSuccessResponse:
@@ -2024,6 +2060,12 @@ components:
           rootUserName: Lorem Ipsum
           rootUserPreferredUsername: username
           rootUserPhone: "+1234567890"
+
+    GetDelegateTokenRequest:
+      value:
+        principal: hrn:XlK5h64gND::iam-user/Bob
+        expiry: 3600
+        policy: hrn:XlK5h64gND::iam-policy/dataReadOnly
 
 
     # Response examples
@@ -2618,6 +2660,30 @@ components:
                 1. inviterUserHrn : string (required) - hrn of the user who is inviting the new user
                 2. policies: array<string> (required) - policies to be attached to the new user
           additionalProperties: true
+
+    GetDelegateTokenRequest:
+      description: payload to generate a delegate_token
+      type: object
+      additionalProperties: false
+      required:
+        - policy
+      properties:
+        principal:
+          description: Principal to delegate the token to. Will default to the requestor if not provided
+          type: string
+        expiry:
+          description: |
+              Expiry in seconds from the time of generation. 
+              If not provided, generated token will have the expiry of the token used for requesting.
+              If a credential is used for requesting, expiry will be 24 hours from the time of requesting.
+          type: integer
+          format: int64
+        policy:
+          description: |
+            Policy with which to generate the delegate token.
+            Can be just the name of the policy if it is in the requestors organization or a complete policy resourceHrn
+          type: string
+
 
     # Responses:
     BaseSuccessResponse:

--- a/src/main/kotlin/com/hypto/iam/server/Application.kt
+++ b/src/main/kotlin/com/hypto/iam/server/Application.kt
@@ -199,9 +199,9 @@ fun Application.handleRequest() {
                     passcodeRepo.getValidPasscode(value, VerifyEmailRequest.Purpose.invite)?.let {
                         val metadata = InviteMetadata(passcodeService.decryptMetadata(it.metadata!!))
                         return@validate UserPrincipal(
-                            TokenCredential(tokenCredential.value, TokenType.PASSCODE),
-                            metadata.inviterUserHrn,
-                            principalPolicyService.fetchEntitlements(metadata.inviterUserHrn)
+                            tokenCredential = TokenCredential(tokenCredential.value, TokenType.PASSCODE),
+                            hrnStr = metadata.inviterUserHrn,
+                            policies = principalPolicyService.fetchEntitlements(metadata.inviterUserHrn)
                         )
                     }
                 }

--- a/src/main/kotlin/com/hypto/iam/server/Constants.kt
+++ b/src/main/kotlin/com/hypto/iam/server/Constants.kt
@@ -27,5 +27,6 @@ class Constants private constructor() {
         const val AUTHORIZATION_HEADER = "Authorization"
         const val SECRET_PREFIX = "$"
         const val JOOQ_QUERY_NAME = "queryName"
+        const val SECONDS_IN_DAY = 24 * 60 * 60L
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -12,6 +12,7 @@ import com.hypto.iam.server.service.UserPrincipalService
 import com.hypto.iam.server.utils.Hrn
 import com.hypto.iam.server.utils.HrnFactory
 import com.hypto.iam.server.utils.policy.PolicyBuilder
+import io.jsonwebtoken.Claims
 import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.http.auth.parseAuthorizationHeader
 import io.ktor.server.application.ApplicationCall
@@ -64,6 +65,7 @@ data class ApiPrincipal(
 data class UserPrincipal(
     override val tokenCredential: TokenCredential,
     val hrnStr: String,
+    val claims: Claims? = null,
     val policies: PolicyBuilder
 ) : IamPrincipal() {
     val hrn: Hrn = HrnFactory.getHrn(hrnStr)

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -18,6 +18,7 @@ import com.hypto.iam.server.models.CreateOrganizationRequest
 import com.hypto.iam.server.models.CreatePolicyRequest
 import com.hypto.iam.server.models.CreateResourceRequest
 import com.hypto.iam.server.models.CreateUserRequest
+import com.hypto.iam.server.models.GetDelegateTokenRequest
 import com.hypto.iam.server.models.PolicyAssociationRequest
 import com.hypto.iam.server.models.PolicyStatement
 import com.hypto.iam.server.models.ResetPasswordRequest
@@ -165,6 +166,10 @@ fun VerifyEmailRequest.validate(): VerifyEmailRequest {
 
 fun UsernamePasswordCredential.validate(): UsernamePasswordCredential {
     return usernamePasswordCredentialValidation.validateAndThrowOnFailure(this)
+}
+
+fun GetDelegateTokenRequest.validate(): GetDelegateTokenRequest {
+    return getDelegateTokenRequestValidation.validateAndThrowOnFailure(this)
 }
 
 // Validations used by ValidationBuilders
@@ -446,4 +451,8 @@ val usernamePasswordCredentialValidation = Validation<UsernamePasswordCredential
     UsernamePasswordCredential::password required {
         run(credentialPasswordCheck)
     }
+}
+
+val getDelegateTokenRequestValidation = Validation<GetDelegateTokenRequest> {
+    GetDelegateTokenRequest::policy required {}
 }


### PR DESCRIPTION
A delegate token is a token which a user with "delegatePolicy" permission on a policy resource can generate with custom expiry. This enables users to generate temporary JWT tokens to be shared with non-IAM principal entities to support numerous use cases.