### PR TITLE
:sparkles: feat: use single Cognito user pool for all users

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/configs/AppConfig.kt
+++ b/src/main/kotlin/com/hypto/iam/server/configs/AppConfig.kt
@@ -1,5 +1,6 @@
 package com.hypto.iam.server.configs
 
+import com.hypto.iam.server.idp.IdentityGroup
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
 
@@ -10,7 +11,8 @@ data class AppConfig(
     val newrelic: Newrelic,
     val aws: Aws,
     val postHook: PostHook,
-    val onboardRoutes: OnboardRoutes
+    val onboardRoutes: OnboardRoutes,
+    val cognito: IdentityGroup
 ) {
     /**
      * Environment variables should be in Snake case.

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -48,16 +48,16 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
     private val gson: Gson by inject()
     private val txMan: TxMan by inject()
     private val httpClient: OkHttpClient by inject()
+    private val appConfig: AppConfig by inject()
 
     override suspend fun createOrganization(
         request: CreateOrganizationRequest
     ): Pair<Organization, TokenResponse> {
         val organizationId = idGenerator.organizationId()
+        val identityGroup = appConfig.cognito
         val username = idGenerator.username()
         val logTimestamp = LocalDateTime.now()
-
         val rootUserFromRequest = request.rootUser
-        val identityGroup = identityProvider.createIdentityGroup(organizationId)
 
         @Suppress("TooGenericExceptionCaught")
         try {
@@ -117,7 +117,6 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
         } catch (e: Exception) {
             logger.error(e) { "Exception when creating organization. Rolling back..." }
 
-            identityProvider.deleteIdentityGroup(identityGroup)
             throw e.cause ?: e
         }
     }

--- a/src/main/kotlin/com/hypto/iam/server/service/PasscodeService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/PasscodeService.kt
@@ -142,11 +142,14 @@ class PasscodeServiceImpl : KoinComponent, PasscodeService {
             Purpose.invite -> AppConfig.configuration.onboardRoutes.invite
         }
 
-        return link.setParameter("passcode", passcode)
-            .setParameter("email", Base64.getEncoder().encodeToString(email.toByteArray()))
-            .setParameter("organizationId", organizationId)
-            .build()
-            .toString()
+        link.setParameter("passcode", passcode)
+        link.setParameter("email", Base64.getEncoder().encodeToString(email.toByteArray()))
+
+        organizationId?.let {
+            link.setParameter("organizationId", it)
+        }
+
+        return link.build().toString()
     }
 
     private fun sendSignupPasscode(email: String, passcode: String): Boolean {

--- a/src/main/resources/default_config.json
+++ b/src/main/resources/default_config.json
@@ -55,5 +55,13 @@
     "signup": "/signup",
     "reset": "/organizations/users/resetPassword",
     "invite": "/organizations/users/verifyUser"
+  },
+  "cognito": {
+    "id": "<user pool id>",
+    "name": "<user pool name>",
+    "metadata": {
+      "iam-client-id": "<placeholder for IAM client id>"
+    },
+    "identitySource": "AWS_COGNITO"
   }
 }

--- a/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/OrganizationApiKtTest.kt
@@ -32,7 +32,6 @@ import io.ktor.http.withCharset
 import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
-import io.mockk.verify
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.Test
 import org.koin.test.inject
 import org.koin.test.mock.declareMock
 import org.testcontainers.junit.jupiter.Testcontainers
-import software.amazon.awssdk.services.cognitoidentityprovider.model.DeleteUserPoolRequest
 
 @Testcontainers
 internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
@@ -340,9 +338,6 @@ internal class OrganizationApiKtTest : AbstractContainerBaseTest() {
                 setBody(gson.toJson(requestBody))
             }
             val responseBody = gson.fromJson(response.bodyAsText(), CreateOrganizationResponse::class.java)
-            verify {
-                cognitoClient.deleteUserPool(any<DeleteUserPoolRequest>())
-            }
         }
     }
 

--- a/src/test/kotlin/com/hypto/iam/server/apis/TokenApiTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/TokenApiTest.kt
@@ -7,6 +7,8 @@ import com.hypto.iam.server.db.repositories.MasterKeysRepo
 import com.hypto.iam.server.helpers.AbstractContainerBaseTest
 import com.hypto.iam.server.helpers.DataSetupHelperV2.createOrganization
 import com.hypto.iam.server.helpers.DataSetupHelperV2.createResourceActionHrn
+import com.hypto.iam.server.idp.IdentityGroup
+import com.hypto.iam.server.idp.IdentityProvider
 import com.hypto.iam.server.models.CreateOrganizationResponse
 import com.hypto.iam.server.models.CreatePolicyRequest
 import com.hypto.iam.server.models.GetDelegateTokenRequest
@@ -302,6 +304,14 @@ class TokenApiTest : AbstractContainerBaseTest() {
                             "inviteUserTemplateId",
                             "resetPasswordTemplateId",
                             true
+                        )
+                    }
+                    every { this@declareMock.cognito } answers {
+                        IdentityGroup(
+                            id = "us-east-1_id",
+                            name = "user-pool-name",
+                            identitySource = IdentityProvider.IdentitySource.AWS_COGNITO,
+                            metadata = mapOf("iam-client-id" to "id")
                         )
                     }
                 }
@@ -782,6 +792,14 @@ class TokenApiTest : AbstractContainerBaseTest() {
                             "inviteUserTemplateId",
                             "resetPasswordTemplateId",
                             true
+                        )
+                    }
+                    every { this@declareMock.cognito } answers {
+                        IdentityGroup(
+                            id = "us-east-1_id",
+                            name = "user-pool-name",
+                            identitySource = IdentityProvider.IdentitySource.AWS_COGNITO,
+                            metadata = mapOf("iam-client-id" to "id")
                         )
                     }
                 }


### PR DESCRIPTION
### Problem
- Fast exhausting resource limit of _User Pool_ in _AWS Cognito_

### Solution
- Use the same _User Pool_ in _AWS Cognito_ from `default_config.json`

### Tests
- Locally tested by creating new user and it falls into one user pool
- Removed `DeleteUserPoolRequest` from test as only one organization will be present
- Added mock for `IdentityGroup` as replacement for `appConfig.cognito`

### Tasks
- [ ] Terraform Changes
  - [ ] `staging`
  - [ ] `sandbox`
  - [ ] `production`