### PR TITLE
:sparkles: feat: create password for OAuth users and minor bug fixes

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -345,6 +345,34 @@ paths:
         default:
           $ref: '#/components/responses/ErrorResponse'
 
+  /organizations/{organization_id}/users/{user_name}/create_password:
+    post:
+      tags:
+        - User Management
+      summary: Create password for a user
+      description: Create password for a user
+      operationId: createPassword
+      parameters:
+        - $ref: '#/components/parameters/user_name'
+        - $ref: '#/components/parameters/organization_id'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateUserPasswordRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/BaseSuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
   /organizations/{organization_id}/users/resetPassword:
     post:
       tags:
@@ -1439,6 +1467,17 @@ components:
             ChangeUserPasswordRequest:
               $ref: '#/components/examples/ChangeUserPasswordRequest'
 
+    CreateUserPasswordRequest:
+      description: Payload to set user password
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateUserPasswordRequest'
+          examples:
+            CreateUserPasswordRequest:
+              $ref: '#/components/examples/CreateUserPasswordRequest'
+
     ResetPasswordRequest:
       description: Payload to reset password
       required: true
@@ -2024,6 +2063,11 @@ components:
         oldPassword: Old@Password123
         newPassword: New@Password123
 
+    CreateUserPasswordRequest:
+      summary: sample set user password request
+      value:
+        password: Password@123
+
     ResetPasswordRequest:
       summary: sample reset password request
       value:
@@ -2569,6 +2613,17 @@ components:
           type: string
           maxLength: 100
         newPassword:
+          type: string
+          maxLength: 100
+
+    CreateUserPasswordRequest:
+      description: Payload to set user password
+      type: object
+      additionalProperties: false
+      required:
+        - password
+      properties:
+        password:
           type: string
           maxLength: 100
 

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -12,12 +12,13 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.koin.core.qualifier.named
 
 const val PROFILE_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
 const val ACCESS_TOKEN_KEY = "access_token"
 object GoogleAuthProvider : BaseAuthProvider(), KoinComponent {
     val gson: Gson by inject()
-    private val httpClient: OkHttpClient by inject()
+    private val httpClient: OkHttpClient by inject(named("AuthProvider"))
 
     override fun getProviderName() = "google"
 

--- a/src/main/kotlin/com/hypto/iam/server/configs/AppConfig.kt
+++ b/src/main/kotlin/com/hypto/iam/server/configs/AppConfig.kt
@@ -113,7 +113,8 @@ data class AppConfig(
                     EnvironmentVariablesPropertySource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
                 ).withReport().build().loadConfigOrThrow<AppConfig>("/default_config.json")
         ) {
-            // Convert cognito metadata keys from snake case to hyphenated because terraform doesn't support snake case as per Karuppiah's comment
+            // Convert cognito metadata keys from snake case to hyphenated
+            // because terraform doesn't support snake case as per Karuppiah's comment
             copy(
                 cognito = cognito.copy(
                     metadata = cognito.metadata.entries.associate {

--- a/src/main/kotlin/com/hypto/iam/server/di/Modules.kt
+++ b/src/main/kotlin/com/hypto/iam/server/di/Modules.kt
@@ -6,6 +6,8 @@ import com.google.gson.JsonDeserializer
 import com.google.gson.JsonPrimitive
 import com.google.gson.JsonSerializer
 import com.hypto.iam.server.MicrometerConfigs
+import com.hypto.iam.server.authProviders.AuthProviderRegistry
+import com.hypto.iam.server.authProviders.GoogleAuthProvider
 import com.hypto.iam.server.configs.AppConfig
 import com.hypto.iam.server.db.repositories.ActionRepo
 import com.hypto.iam.server.db.repositories.AuthProviderRepo
@@ -150,6 +152,8 @@ val applicationModule = module {
         }.connectionPool(ConnectionPool(MAX_IDLE_CONNECTIONS, KEEP_ALIVE_DURATION, TimeUnit.MINUTES))
     }
     single(named("AuthProvider")) { get<OkHttpClient.Builder>().build() }
+    single { AuthProviderRegistry }
+    single(null, true) { GoogleAuthProvider }
 }
 
 fun getCognitoIdentityProviderClient(

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -17,6 +17,7 @@ import com.hypto.iam.server.models.CreateCredentialRequest
 import com.hypto.iam.server.models.CreateOrganizationRequest
 import com.hypto.iam.server.models.CreatePolicyRequest
 import com.hypto.iam.server.models.CreateResourceRequest
+import com.hypto.iam.server.models.CreateUserPasswordRequest
 import com.hypto.iam.server.models.CreateUserRequest
 import com.hypto.iam.server.models.GetDelegateTokenRequest
 import com.hypto.iam.server.models.PolicyAssociationRequest
@@ -138,6 +139,10 @@ fun UpdateUserRequest.validate(): UpdateUserRequest {
 
 fun ChangeUserPasswordRequest.validate(): ChangeUserPasswordRequest {
     return changeUserPasswordRequestValidation.validateAndThrowOnFailure(this)
+}
+
+fun CreateUserPasswordRequest.validate(): CreateUserPasswordRequest {
+    return createUserPasswordRequestValidation.validateAndThrowOnFailure(this)
 }
 
 fun ResetPasswordRequest.validate(): ResetPasswordRequest {
@@ -444,6 +449,12 @@ val changeUserPasswordRequestValidation = Validation {
         run(passwordCheck)
     }
     ChangeUserPasswordRequest::newPassword required {
+        run(passwordCheck)
+    }
+}
+
+val createUserPasswordRequestValidation = Validation {
+    CreateUserPasswordRequest::password required {
         run(passwordCheck)
     }
 }

--- a/src/main/resources/default_config.json
+++ b/src/main/resources/default_config.json
@@ -60,7 +60,7 @@
     "id": "<user pool id>",
     "name": "<user pool name>",
     "metadata": {
-      "iam-client-id": "<placeholder for IAM client id>"
+      "iam_client_id": "<placeholder for IAM client id>"
     },
     "identitySource": "AWS_COGNITO"
   }


### PR DESCRIPTION
### Problem
- Unable to use password access for OAuth users
- Minor bug: `GoogleAuthProvider` did not self register
- Minor bug: Named dependency was not injected properly

### Solution
- Created new `/organizations/{organization_id}/users/{user_id}/create_password` API to create password access for OAuth users
- Minor bug fix: Dependency injection with loading at start of application
- Minor bug fix: Using `named()` function injected properly

### Tests
- Locally tested using `staging` cognito credentials
1. Signup - Create organization using email
2. Signup - Create organization using Google
3. Login - using email and password
4. Login - using Google
5. Set password - for OAuth account