### PR TITLE
:bug: fix: null pointer exception on update user

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
@@ -311,7 +311,7 @@ class UsersServiceImpl : KoinComponent, UsersService {
             ?: throw EntityNotFoundException("User not found")
 
         val userStatus = status?.toUserStatus()
-        if (userRecord.loginAccess == true) {
+        if (userRecord.loginAccess == true && org.metadata != null) {
             val identityGroup = gson.fromJson(org.metadata.data(), IdentityGroup::class.java)
 
             identityProvider.updateUser(


### PR DESCRIPTION
### Problem
- Update users resulted in 500 for some users 

### Solution
- We try to update info in identity provider for every update, but users who have signed up through google will not have info in identity provider (Cognito)
- Added null check, to skip update in identity provider

### Tests
- Tested locally in dev environment
