### PR TITLE
🐛 fix: make `credentials` inactive on `deleteUser` and fix `org.metadata == null` bug

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/apis/UsersApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UsersApi.kt
@@ -5,6 +5,7 @@ package com.hypto.iam.server.apis
 import com.google.gson.Gson
 import com.hypto.iam.server.configs.AppConfig
 import com.hypto.iam.server.db.repositories.PasscodeRepo
+import com.hypto.iam.server.db.repositories.UserAuthRepo
 import com.hypto.iam.server.extensions.PaginationContext
 import com.hypto.iam.server.models.ChangeUserPasswordRequest
 import com.hypto.iam.server.models.CreateUserPasswordRequest
@@ -25,6 +26,7 @@ import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.PasscodeService
 import com.hypto.iam.server.service.PrincipalPolicyService
 import com.hypto.iam.server.service.TokenService
+import com.hypto.iam.server.service.TokenServiceImpl
 import com.hypto.iam.server.service.UsersService
 import com.hypto.iam.server.utils.ApplicationIdUtil
 import com.hypto.iam.server.utils.HrnFactory
@@ -52,6 +54,7 @@ fun Route.createUsersApi() {
     val passcodeService: PasscodeService by inject()
     val idGenerator: ApplicationIdUtil.Generator by inject()
     val tokenService: TokenService by inject()
+    val userAuthRepo: UserAuthRepo by inject()
 
     // **** Create User api ****//
 
@@ -94,6 +97,11 @@ fun Route.createUsersApi() {
                 verified = verified,
                 loginAccess = loginAccess,
                 policies = policies
+            )
+            userAuthRepo.create(
+                hrn = user.hrn,
+                providerName = TokenServiceImpl.ISSUER,
+                authMetadata = null
             )
 
             val token = tokenService.generateJwtToken(ResourceHrn(user.hrn))

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/CredentialsRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/CredentialsRepo.kt
@@ -31,12 +31,26 @@ object CredentialsRepo : BaseRepo<CredentialsRecord, Credentials, UUID>() {
     }
 
     /**
-     * Fetch records that have `user_hrn = value`
+     * Fetch records that matches the `id` and `user_hrn`
      */
     suspend fun fetchByIdAndUserHrn(id: UUID, value: String): CredentialsRecord? {
         return ctx("credentials.fetch_by_id").selectFrom(CREDENTIALS)
             .where(CREDENTIALS.ID.eq(id).and(CREDENTIALS.USER_HRN.eq(value)))
             .fetchOne()
+    }
+
+    /**
+     * Updates status to `inactive` for users with `userHrn`
+     * @return true on successful update. false otherwise.
+     */
+    suspend fun updateStatusForUser(userHrn: String, status: Credential.Status = Credential.Status.inactive): Boolean {
+        val count = ctx("credentials.update_status_for_user")
+            .update(CREDENTIALS)
+            .set(CREDENTIALS.STATUS, status.value)
+            .set(CREDENTIALS.UPDATED_AT, LocalDateTime.now())
+            .where(CREDENTIALS.USER_HRN.eq(userHrn))
+            .execute()
+        return count > 0
     }
 
     /**

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -34,6 +34,7 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
     ): List<UsersRecord> {
         return ctx("users.fetchMany").selectFrom(USERS)
             .where(USERS.ORGANIZATION_ID.eq(organizationId))
+            .and(USERS.DELETED.eq(false))
             .paginate(USERS.CREATED_AT, paginationContext)
             .fetch()
     }

--- a/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
+++ b/src/main/kotlin/com/hypto/iam/server/idp/CognitoProviderImpl.kt
@@ -2,6 +2,7 @@
 
 package com.hypto.iam.server.idp
 
+import com.hypto.iam.server.configs.AppConfig
 import com.hypto.iam.server.exceptions.InternalException
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.idp.CognitoConstants.ACTION_SUPPRESS
@@ -69,6 +70,7 @@ object CognitoConstants {
 class CognitoIdentityProviderImpl : IdentityProvider, KoinComponent {
     private val cognitoClient: CognitoIdentityProviderClient by inject()
     private val aliasAttributeTypes = mutableListOf(AliasAttributeType.EMAIL, AliasAttributeType.PREFERRED_USERNAME)
+    private val appConfig: AppConfig by inject()
 
     override suspend fun createIdentityGroup(name: String, configuration: Configuration): IdentityGroup {
         try {
@@ -121,6 +123,7 @@ class CognitoIdentityProviderImpl : IdentityProvider, KoinComponent {
 
     override suspend fun deleteIdentityGroup(identityGroup: IdentityGroup) {
         try {
+            if (identityGroup == appConfig.cognito) return
             val deletePoolRequest = DeleteUserPoolRequest.builder().userPoolId(identityGroup.id).build()
             cognitoClient.deleteUserPool(deletePoolRequest)
         } catch (e: Exception) {

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -269,8 +269,10 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
         val org = organizationRepo.findById(id) ?: throw EntityNotFoundException("Organization id - $id not found")
         organizationRepo.deleteById(id)
 
-        val identityGroup = gson.fromJson(org.metadata.data(), IdentityGroup::class.java)
-        identityProvider.deleteIdentityGroup(identityGroup)
+        if (org.metadata != null) {
+            val identityGroup = gson.fromJson(org.metadata.data(), IdentityGroup::class.java)
+            if (identityGroup != appConfig.cognito) identityProvider.deleteIdentityGroup(identityGroup)
+        }
 
         return BaseSuccessResponse(true)
     }

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -271,7 +271,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
 
         if (org.metadata != null) {
             val identityGroup = gson.fromJson(org.metadata.data(), IdentityGroup::class.java)
-            if (identityGroup != appConfig.cognito) identityProvider.deleteIdentityGroup(identityGroup)
+            identityProvider.deleteIdentityGroup(identityGroup)
         }
 
         return BaseSuccessResponse(true)


### PR DESCRIPTION
### Problem
1. `POST /organizations/{organization_id}/users` did not create record in `userAuth` table
2. `GET  /organizations/{organization_id}/users` fetched all users including deleted users
3. `createUser()` does not work if root organization does not have metadata pointing to Cognito user pool
4. `deleteOrganization()` deletes the Cognito user pool in the metadata
5. `DELETE /organizations/{organization_id}/users` did not affect the credentials

### Solution
1. Added `userAuth` record
2. Returned only existing users, i.e., `deleted = false`
3. Default to `appConfig.cognito` if metadata does not exist and add that to `organization` table as well 
4. Added guard to prevent deletion of common user pool, i.e., `identityGroup != appConfig.cognito` 
5. Update the credentials status to `inactive` on deletion of user

### Tests
- Tested locally in dev environment using Postman:
  - Invited new user and deleted that user
  - Invited new user, created few credentials and deleted that user