### PR TITLE
:sparkles: feat: add microsoft authorization and refactor delete organization

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/authProviders/AuthProviderRegistry.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/AuthProviderRegistry.kt
@@ -5,6 +5,7 @@ object AuthProviderRegistry {
 
     init {
         registerProvider(GoogleAuthProvider)
+        registerProvider(MicrosoftAuthProvider)
     }
 
     fun getProvider(providerName: String) = providerRegistry[providerName]

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/CredentialsRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/CredentialsRepo.kt
@@ -106,4 +106,12 @@ object CredentialsRepo : BaseRepo<CredentialsRecord, Credentials, UUID>() {
         val count = record.delete()
         return count > 0
     }
+
+    suspend fun deleteByUserHrn(userHrn: String): Boolean {
+        val count = ctx("credentials.delete_by_user_hrn")
+            .deleteFrom(CREDENTIALS)
+            .where(CREDENTIALS.USER_HRN.like("%$userHrn%"))
+            .execute()
+        return count > 0
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/PasscodeRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/PasscodeRepo.kt
@@ -123,4 +123,12 @@ object PasscodeRepo : BaseRepo<PasscodesRecord, Passcodes, String>() {
             .execute()
         return count > 0
     }
+
+    suspend fun deleteByOrganizationId(organizationId: String): Boolean {
+        val count = ctx("passcodes.delete_by_organization_id")
+            .deleteFrom(PASSCODES)
+            .where(PASSCODES.ORGANIZATION_ID.eq(organizationId))
+            .execute()
+        return count > 0
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/PoliciesRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/PoliciesRepo.kt
@@ -12,6 +12,7 @@ import org.jooq.impl.DAOImpl
 
 data class RawPolicyPayload(val hrn: ResourceHrn, val description: String? = null, val statements: String)
 
+@Suppress("TooManyFunctions")
 object PoliciesRepo : BaseRepo<PoliciesRecord, Policies, String>() {
 
     private val idFun = fun (policy: Policies) = policy.hrn
@@ -103,5 +104,13 @@ object PoliciesRepo : BaseRepo<PoliciesRecord, Policies, String>() {
             .from(POLICIES)
             .where(POLICIES.HRN.`in`(hrns))
             .fetchOne(0, Int::class.java) == hrns.size
+    }
+
+    suspend fun deleteByOrganizationId(organizationId: String): Boolean {
+        val count = ctx("policies.delete_by_organization_id")
+            .deleteFrom(POLICIES)
+            .where(POLICIES.ORGANIZATION_ID.eq(organizationId))
+            .execute()
+        return count > 0
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/PrincipalPoliciesRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/PrincipalPoliciesRepo.kt
@@ -66,4 +66,9 @@ object PrincipalPoliciesRepo : BaseRepo<PrincipalPoliciesRecord, PrincipalPolici
         .deleteFrom(PRINCIPAL_POLICIES)
         .where(PRINCIPAL_POLICIES.PRINCIPAL_HRN.eq(userHrn.toString()), PRINCIPAL_POLICIES.POLICY_HRN.`in`(policies))
         .execute() > 0
+
+    suspend fun deleteByPrincipalHrn(principalHrn: String): Boolean = ctx("principalPolicies.deleteByPrincipalHrn")
+        .deleteFrom(PRINCIPAL_POLICIES)
+        .where(PRINCIPAL_POLICIES.PRINCIPAL_HRN.like("%$principalHrn%"))
+        .execute() > 0
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
@@ -61,4 +61,12 @@ object UserAuthRepo : BaseRepo<UserAuthRecord, UserAuth, UserAuthPk>() {
             .where(USER_AUTH.USER_HRN.eq(userHrn.toString()))
             .fetch()
     }
+
+    suspend fun deleteByUserHrn(userHrn: String): Boolean {
+        val count = ctx("userAuth.deleteByUserHrn")
+            .deleteFrom(USER_AUTH)
+            .where(USER_AUTH.USER_HRN.eq(userHrn))
+            .execute()
+        return count > 0
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -108,4 +108,12 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             .and(USERS.VERIFIED.eq(true))
             .fetchOne()
     }
+
+    suspend fun deleteByOrganizationId(organizationId: String): Boolean {
+        val count = ctx("users.delete_by_organization_id")
+            .deleteFrom(USERS)
+            .where(USERS.ORGANIZATION_ID.eq(organizationId))
+            .execute()
+        return count > 0
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -102,6 +102,13 @@ class TokenAuthenticationProvider internal constructor(
             if (!authSchemeExists) {
                 return@tokenAuthenticationCredentials it
             }
+            if (call.request.headers.contains("x-issuer")) {
+                if (!it.startsWith("Bearer")) {
+                    throw AuthenticationException("Invalid token")
+                } else {
+                    return@tokenAuthenticationCredentials it.substringAfter("Bearer ")
+                }
+            }
             @Suppress("TooGenericExceptionCaught")
             try {
                 val result = when (val header = parseAuthorizationHeader(it)) {


### PR DESCRIPTION
### Problem
- Delete organization deletes the common identity group after the merging all identity groups into one 
- Feature request for Microsoft login

### Solutions
- Prevent deletion of identity group and delete all data across all entities
- Implemented AuthProvider for Microsoft login

### Tests
- Locally tested in dev environment