### PR TITLE
:sparkles: fix: login with Microsoft vulnerability

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -513,6 +513,32 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
+    post:
+      tags:
+        - User Authorization Methods Management
+      summary: Add authorization methods to a user entity associated with the organization
+      description: Add authorization methods to a User
+      operationId: addUserAuthMethods
+      parameters:
+        - $ref: '#/components/parameters/user_name'
+        - $ref: '#/components/parameters/organization_id'
+      requestBody:
+        $ref: '#/components/requestBodies/AddUserAuthMethodRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/BaseSuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
 
   # credential
   /organizations/{organization_id}/users/{user_name}/credentials:
@@ -1512,6 +1538,17 @@ components:
             ResetPasswordRequest:
               $ref: '#/components/examples/ResetPasswordRequest'
 
+    AddUserAuthMethodRequest:
+      description: Payload to add user auth method
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AddUserAuthMethodRequest'
+          examples:
+            AddUserAuthMethodRequest:
+              $ref: '#/components/examples/AddUserAuthMethodRequest'
+
     CreateCredentialRequest:
       description: Payload to create credential
       required: true
@@ -2095,6 +2132,11 @@ components:
         email: bob@acme.com
         password: <new password>
 
+    AddUserAuthMethodRequest:
+      summary: sample add user auth methods request
+      value:
+        token: <JWT token or Access token provided by the auth provider>
+
     CreateCredentialRequest:
       summary: sample create credential request
       value:
@@ -2608,6 +2650,14 @@ components:
         password:
           type: string
           maxLength: 50
+
+    AddUserAuthMethodRequest:
+      description: Payload to add user auth methods
+      type: object
+      additionalProperties: false
+      properties:
+        token:
+          type: string
 
     CreateCredentialRequest:
       description: Payload to create credential

--- a/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
@@ -47,7 +47,8 @@ fun Route.createOrganizationApi() {
                 companyName = oAuthUserPrincipal.companyName,
                 name = oAuthUserPrincipal.name,
                 email = oAuthUserPrincipal.email,
-                issuer = oAuthUserPrincipal.issuer
+                issuer = oAuthUserPrincipal.issuer,
+                metadata = oAuthUserPrincipal.metadata
             )
             call.respondText(
                 text = gson.toJson(CreateOrganizationResponse(organization, tokenResponse.token)),

--- a/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
@@ -75,7 +75,9 @@ suspend fun generateTokenOauth(call: ApplicationCall, context: ApplicationCall) 
     val authProvider = AuthProviderRegistry.getProvider(principal.issuer) ?: throw AuthenticationException(
         "Invalid issuer"
     )
-    authProvider.authenticate(principal.metadata, AuthMetadata.from(userAuth.authMetadata))
+    userAuth.authMetadata?.let {
+        authProvider.authenticate(principal.metadata, AuthMetadata.from(it))
+    }
 
     val response = tokenService.generateJwtToken(ResourceHrn(user.hrn))
 

--- a/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
@@ -1,15 +1,20 @@
 package com.hypto.iam.server.apis
 
 import com.google.gson.Gson
+import com.hypto.iam.server.models.AddUserAuthMethodRequest
 import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.UserAuthService
+import com.hypto.iam.server.validators.validate
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import org.koin.ktor.ext.inject
 
 fun Route.userAuthApi() {
@@ -28,6 +33,25 @@ fun Route.userAuthApi() {
                 text = gson.toJson(response),
                 contentType = ContentType.Application.Json,
                 status = HttpStatusCode.OK
+            )
+        }
+    }
+
+    withPermission(
+        "createUserAuth",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1)
+    ) {
+        post("/organizations/{organization_id}/users/{id}/auth_methods") {
+            val organizationId = call.parameters["organization_id"]!!
+            val userId = call.parameters["id"]!!
+            val issuer = call.request.headers["X-Issuer"] ?: throw BadRequestException("X-Issuer is missing")
+            val request = call.receive<AddUserAuthMethodRequest>().validate()
+            val token = request.token ?: throw BadRequestException("Token is missing")
+            val response = userAuthService.createUserAuth(organizationId, userId, issuer, token)
+            call.respondText(
+                text = gson.toJson(response),
+                contentType = ContentType.Application.Json,
+                status = HttpStatusCode.Created
             )
         }
     }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -1,11 +1,12 @@
 package com.hypto.iam.server.authProviders
 
-import com.hypto.iam.server.security.AuthMetadata
+import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
 
 interface BaseAuthProvider {
+    val isVerifiedProvider: Boolean
     fun getProviderName(): String
     fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
-    fun authenticate(principalMetadata: AuthMetadata? = null, authMetadata: AuthMetadata? = null)
+    suspend fun authenticate(principal: OAuthUserPrincipal, userAuthRecord: UserAuthRecord)
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -7,5 +7,5 @@ import com.hypto.iam.server.security.TokenCredential
 interface BaseAuthProvider {
     fun getProviderName(): String
     fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
-    fun authenticate(principalMetadata: AuthMetadata? = null, authMetadata: AuthMetadata)
+    fun authenticate(principalMetadata: AuthMetadata? = null, authMetadata: AuthMetadata? = null)
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -1,9 +1,11 @@
 package com.hypto.iam.server.authProviders
 
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
 
 interface BaseAuthProvider {
     fun getProviderName(): String
     fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
+    fun authenticate(principalMetadata: AuthMetadata? = null, authMetadata: AuthMetadata)
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -49,7 +49,7 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
         )
     }
 
-    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata) {
+    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata?) {
         return
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.hypto.iam.server.ROOT_ORG
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.logger
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.security.AuthenticationException
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
@@ -46,6 +47,10 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
             googleUser.hd ?: "",
             getProviderName()
         )
+    }
+
+    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata) {
+        return
     }
 }
 

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -2,9 +2,9 @@ package com.hypto.iam.server.authProviders
 
 import com.google.gson.Gson
 import com.hypto.iam.server.ROOT_ORG
+import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.logger
-import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.security.AuthenticationException
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
@@ -21,6 +21,7 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
 
     val gson: Gson by inject()
     private val httpClient: OkHttpClient by inject(named("AuthProvider"))
+    override val isVerifiedProvider: Boolean = true
 
     override fun getProviderName() = "google"
 
@@ -49,7 +50,7 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
         )
     }
 
-    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata?) {
+    override suspend fun authenticate(principal: OAuthUserPrincipal, userAuthRecord: UserAuthRecord) {
         return
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.hypto.iam.server.ROOT_ORG
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.logger
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.security.AuthenticationException
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
@@ -48,10 +49,15 @@ object MicrosoftAuthProvider : BaseAuthProvider, KoinComponent {
             microsoftUser.displayName,
             "",
             getProviderName(),
-            mapOf(
-                "id" to microsoftUser.id,
-            )
+            AuthMetadata(id = microsoftUser.id)
         )
+    }
+
+    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata) {
+        // Reason to use id instead of email is because email can be changed in Microsoft profile (https://0x8.in/blog/2021/04/30/mip-oid-sub/)
+        if (principalMetadata?.id == null || principalMetadata.id != authMetadata.id) {
+            throw AuthenticationException("User is not authenticated with Microsoft")
+        }
     }
 }
 

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -54,7 +54,8 @@ object MicrosoftAuthProvider : BaseAuthProvider, KoinComponent {
     }
 
     override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata) {
-        // Reason to use id instead of email is because email can be changed in Microsoft profile (https://0x8.in/blog/2021/04/30/mip-oid-sub/)
+        // Reason to use id instead of email is because email can be changed in Microsoft profile
+        // Blog: https://0x8.in/blog/2021/04/30/mip-oid-sub/
         if (principalMetadata?.id == null || principalMetadata.id != authMetadata.id) {
             throw AuthenticationException("User is not authenticated with Microsoft")
         }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -53,10 +53,10 @@ object MicrosoftAuthProvider : BaseAuthProvider, KoinComponent {
         )
     }
 
-    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata) {
+    override fun authenticate(principalMetadata: AuthMetadata?, authMetadata: AuthMetadata?) {
         // Reason to use id instead of email is because email can be changed in Microsoft profile
         // Blog: https://0x8.in/blog/2021/04/30/mip-oid-sub/
-        if (principalMetadata?.id == null || principalMetadata.id != authMetadata.id) {
+        if (principalMetadata?.id == null || principalMetadata.id != authMetadata?.id) {
             throw AuthenticationException("User is not authenticated with Microsoft")
         }
     }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -47,12 +47,16 @@ object MicrosoftAuthProvider : BaseAuthProvider, KoinComponent {
             microsoftUser.mail,
             microsoftUser.displayName,
             "",
-            getProviderName()
+            getProviderName(),
+            mapOf(
+                "id" to microsoftUser.id,
+            )
         )
     }
 }
 
 data class MicrosoftUser(
+    val id: String,
     val mail: String? = null,
     val displayName: String
 )

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
@@ -3,7 +3,6 @@ package com.hypto.iam.server.db.repositories
 import com.hypto.iam.server.db.Tables.USER_AUTH
 import com.hypto.iam.server.db.tables.pojos.UserAuth
 import com.hypto.iam.server.db.tables.records.UserAuthRecord
-import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.utils.Hrn
 import java.time.LocalDateTime
 import org.jooq.DSLContext
@@ -69,24 +68,5 @@ object UserAuthRepo : BaseRepo<UserAuthRecord, UserAuth, UserAuthPk>() {
             .where(USER_AUTH.USER_HRN.eq(userHrn))
             .execute()
         return count > 0
-    }
-
-    suspend fun alreadyExists(metadata: AuthMetadata): Boolean {
-        val count = ctx("userAuth.alreadyExists")
-            .selectCount()
-            .from(USER_AUTH)
-            .where(USER_AUTH.AUTH_METADATA.eq(AuthMetadata.toJsonB(metadata)))
-            .fetchOne(0, Int::class.java)
-        return if (count != null) {
-            count > 0
-        } else {
-            false
-        }
-    }
-
-    fun updateAuthMetadata(userAuth: UserAuthRecord, authMetadata: AuthMetadata): UserAuthRecord {
-        userAuth.authMetadata = AuthMetadata.toJsonB(authMetadata)
-        userAuth.update()
-        return userAuth
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
@@ -71,6 +71,19 @@ object UserAuthRepo : BaseRepo<UserAuthRecord, UserAuth, UserAuthPk>() {
         return count > 0
     }
 
+    suspend fun alreadyExists(metadata: AuthMetadata): Boolean {
+        val count = ctx("userAuth.alreadyExists")
+            .selectCount()
+            .from(USER_AUTH)
+            .where(USER_AUTH.AUTH_METADATA.eq(AuthMetadata.toJsonB(metadata)))
+            .fetchOne(0, Int::class.java)
+        return if (count != null) {
+            count > 0
+        } else {
+            false
+        }
+    }
+
     fun updateAuthMetadata(userAuth: UserAuthRecord, authMetadata: AuthMetadata): UserAuthRecord {
         userAuth.authMetadata = AuthMetadata.toJsonB(authMetadata)
         userAuth.update()

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
@@ -69,4 +69,10 @@ object UserAuthRepo : BaseRepo<UserAuthRecord, UserAuth, UserAuthPk>() {
             .execute()
         return count > 0
     }
+
+    fun updateAuthMetadata(userAuth: UserAuthRecord, authMetadata: Map<String, Any>?): UserAuthRecord {
+        userAuth.authMetadata = JSONB.valueOf(authMetadata.toString())
+        userAuth.update()
+        return userAuth
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserAuthRepo.kt
@@ -3,6 +3,7 @@ package com.hypto.iam.server.db.repositories
 import com.hypto.iam.server.db.Tables.USER_AUTH
 import com.hypto.iam.server.db.tables.pojos.UserAuth
 import com.hypto.iam.server.db.tables.records.UserAuthRecord
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.utils.Hrn
 import java.time.LocalDateTime
 import org.jooq.DSLContext
@@ -70,8 +71,8 @@ object UserAuthRepo : BaseRepo<UserAuthRecord, UserAuth, UserAuthPk>() {
         return count > 0
     }
 
-    fun updateAuthMetadata(userAuth: UserAuthRecord, authMetadata: Map<String, Any>?): UserAuthRecord {
-        userAuth.authMetadata = JSONB.valueOf(authMetadata.toString())
+    fun updateAuthMetadata(userAuth: UserAuthRecord, authMetadata: AuthMetadata): UserAuthRecord {
+        userAuth.authMetadata = AuthMetadata.toJsonB(authMetadata)
         userAuth.update()
         return userAuth
     }

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -28,6 +28,7 @@ import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.response.respond
 import java.util.Base64
 import mu.KotlinLogging
+import org.jooq.JSONB
 
 private val logger = KotlinLogging.logger { }
 
@@ -84,7 +85,7 @@ data class OAuthUserPrincipal(
     val name: String,
     val companyName: String,
     override val issuer: String,
-    val metadata: Map<String, Any>? = null
+    val metadata: AuthMetadata? = null
 ) : IamPrincipal
 
 class TokenAuthenticationProvider internal constructor(
@@ -297,6 +298,22 @@ fun bearerAuthValidation(
             }
         } catch (e: Exception) {
             null
+        }
+    }
+}
+
+data class AuthMetadata(
+    val id: String? = null,
+) {
+    companion object {
+        fun from(json: String): AuthMetadata {
+            return gson.fromJson(json, AuthMetadata::class.java)
+        }
+        fun from(json: JSONB): AuthMetadata {
+            return gson.fromJson(json.data(), AuthMetadata::class.java)
+        }
+        fun toJsonB(authMetadata: AuthMetadata): JSONB {
+            return JSONB.valueOf(gson.toJson(authMetadata))
         }
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -83,7 +83,8 @@ data class OAuthUserPrincipal(
     val email: String,
     val name: String,
     val companyName: String,
-    override val issuer: String
+    override val issuer: String,
+    val metadata: Map<String, Any>? = null
 ) : IamPrincipal
 
 class TokenAuthenticationProvider internal constructor(

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -19,6 +19,7 @@ import com.hypto.iam.server.models.CreateOrganizationRequest
 import com.hypto.iam.server.models.Organization
 import com.hypto.iam.server.models.TokenResponse
 import com.hypto.iam.server.models.VerifyEmailRequest
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.utils.ApplicationIdUtil
 import com.hypto.iam.server.utils.HrnFactory
 import com.hypto.iam.server.utils.IamResources
@@ -144,7 +145,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
         name: String,
         email: String,
         issuer: String,
-        metadata: Map<String, Any>?
+        metadata: AuthMetadata?
     ): Pair<Organization, TokenResponse> {
         val organizationId = idGenerator.organizationId()
         val username = idGenerator.username()
@@ -206,7 +207,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
                 userAuthRepo.create(
                     hrn = userHrn.toString(),
                     providerName = issuer,
-                    authMetadata = metadata?.let { JSONB.jsonb(gson.toJson(it)) }
+                    authMetadata = metadata?.let { AuthMetadata.toJsonB(it) }
                 )
 
                 return@wrap Pair(organization, token)
@@ -304,7 +305,7 @@ interface OrganizationsService {
         name: String,
         email: String,
         issuer: String,
-        metadata: Map<String, Any>? = null
+        metadata: AuthMetadata?
     ): Pair<Organization, TokenResponse>
 
     suspend fun getOrganization(id: String): Organization

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -143,7 +143,8 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
         companyName: String,
         name: String,
         email: String,
-        issuer: String
+        issuer: String,
+        metadata: Map<String, Any>?
     ): Pair<Organization, TokenResponse> {
         val organizationId = idGenerator.organizationId()
         val username = idGenerator.username()
@@ -205,7 +206,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
                 userAuthRepo.create(
                     hrn = userHrn.toString(),
                     providerName = issuer,
-                    authMetadata = null
+                    authMetadata = metadata?.let { JSONB.jsonb(gson.toJson(it)) }
                 )
 
                 return@wrap Pair(organization, token)
@@ -302,7 +303,8 @@ interface OrganizationsService {
         companyName: String,
         name: String,
         email: String,
-        issuer: String
+        issuer: String,
+        metadata: Map<String, Any>? = null
     ): Pair<Organization, TokenResponse>
 
     suspend fun getOrganization(id: String): Organization

--- a/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
@@ -1,10 +1,17 @@
 package com.hypto.iam.server.service
 
+import com.hypto.iam.server.authProviders.AuthProviderRegistry
 import com.hypto.iam.server.db.repositories.OrganizationRepo
 import com.hypto.iam.server.db.repositories.UserAuthRepo
+import com.hypto.iam.server.db.repositories.UserRepo
 import com.hypto.iam.server.exceptions.EntityNotFoundException
+import com.hypto.iam.server.models.BaseSuccessResponse
 import com.hypto.iam.server.models.UserAuthMethod
 import com.hypto.iam.server.models.UserAuthMethodsResponse
+import com.hypto.iam.server.security.AuthMetadata
+import com.hypto.iam.server.security.AuthenticationException
+import com.hypto.iam.server.security.TokenCredential
+import com.hypto.iam.server.security.TokenType
 import com.hypto.iam.server.utils.IamResources
 import com.hypto.iam.server.utils.ResourceHrn
 import org.koin.core.component.KoinComponent
@@ -12,7 +19,35 @@ import org.koin.core.component.inject
 
 class UserAuthServiceImpl : KoinComponent, UserAuthService {
     private val organizationRepo: OrganizationRepo by inject()
+    private val userRepo: UserRepo by inject()
     private val userAuthRepo: UserAuthRepo by inject()
+    override suspend fun createUserAuth(
+        organizationId: String,
+        userId: String,
+        issuer: String,
+        token: String
+    ): BaseSuccessResponse {
+        if (issuer != TokenServiceImpl.ISSUER) {
+            val authProvider = AuthProviderRegistry.getProvider(issuer) ?: throw AuthenticationException(
+                "Invalid issuer"
+            )
+            val oAuthUserPrincipal = authProvider.getProfileDetails(TokenCredential(token, TokenType.OAUTH))
+            val user = userRepo.findByEmail(oAuthUserPrincipal.email) ?: throw AuthenticationException(
+                "User has not signed up yet"
+            )
+            val userAuth = userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, issuer)
+            if (userAuth != null) {
+                userAuthRepo.create(
+                    user.hrn,
+                    oAuthUserPrincipal.issuer,
+                    oAuthUserPrincipal.metadata?.let { AuthMetadata.toJsonB(it) }
+                )
+            } else {
+                throw AuthenticationException("User already has this auth method")
+            }
+        }
+        return BaseSuccessResponse(true)
+    }
 
     override suspend fun listUserAuth(
         organizationId: String,
@@ -33,6 +68,12 @@ class UserAuthServiceImpl : KoinComponent, UserAuthService {
 }
 
 interface UserAuthService {
+    suspend fun createUserAuth(
+        organizationId: String,
+        userId: String,
+        issuer: String,
+        token: String
+    ): BaseSuccessResponse
     suspend fun listUserAuth(
         organizationId: String,
         userHrn: String

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -11,6 +11,7 @@ import com.hypto.iam.server.extensions.hrn
 import com.hypto.iam.server.extensions.noEndSpaces
 import com.hypto.iam.server.extensions.oneOrMoreOf
 import com.hypto.iam.server.extensions.validateAndThrowOnFailure
+import com.hypto.iam.server.models.AddUserAuthMethodRequest
 import com.hypto.iam.server.models.ChangeUserPasswordRequest
 import com.hypto.iam.server.models.CreateActionRequest
 import com.hypto.iam.server.models.CreateCredentialRequest
@@ -57,6 +58,13 @@ fun CreateOrganizationRequest.validate(): CreateOrganizationRequest {
  */
 fun UpdateOrganizationRequest.validate(): UpdateOrganizationRequest {
     return updateOrganizationRequestValidation.validateAndThrowOnFailure(this)
+}
+
+/**
+ * Extension function to validate AddUserAuthMethodRequest input from client
+ */
+fun AddUserAuthMethodRequest.validate(): AddUserAuthMethodRequest {
+    return addUserAuthMethodRequestValidation.validateAndThrowOnFailure(this)
 }
 
 /**
@@ -318,6 +326,10 @@ val updateOrganizationRequestValidation = Validation {
     UpdateOrganizationRequest::description ifPresent {
         run(descriptionCheck)
     }
+}
+
+val addUserAuthMethodRequestValidation = Validation {
+    AddUserAuthMethodRequest::token required {}
 }
 
 val createCredentialRequestValidation = Validation {


### PR DESCRIPTION
### Problem
- Account takeover due to misconfigured Microsoft Azure Active Directory Attribute

### Solution
- Store `oid` in `auth_metadata` column of `iam.user_auth` table
- **Explanation of prevention of attack:** Say the victim’s email is configured against the hacker’s mail in Azure Active Directory, but the `oid` of the hacker’s Microsoft account will not match the `oid` of the victim, thereby denying access.

### Tests
- Yet to test