### PR TITLE
Invite sub-org users to add email/password creds

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -3496,10 +3496,11 @@ components:
       type: object
       additionalProperties: false
       required:
-        - email
         - purpose
       properties:
         email:
+          type: string
+        userHrn:
           type: string
         organizationId:
           type: string

--- a/src/main/kotlin/com/hypto/iam/server/Application.kt
+++ b/src/main/kotlin/com/hypto/iam/server/Application.kt
@@ -6,6 +6,7 @@ import com.hypto.iam.server.apis.actionApi
 import com.hypto.iam.server.apis.authProviderApi
 import com.hypto.iam.server.apis.createOrganizationApi
 import com.hypto.iam.server.apis.createPasscodeApi
+import com.hypto.iam.server.apis.createUserPasswordApi
 import com.hypto.iam.server.apis.createUsersApi
 import com.hypto.iam.server.apis.credentialApi
 import com.hypto.iam.server.apis.deleteOrganizationApi
@@ -137,6 +138,7 @@ fun Application.handleRequest() {
 
         authenticate("bearer-auth", "invite-passcode-auth") {
             createUsersApi()
+            createUserPasswordApi()
         }
 
         authenticate("bearer-auth") {

--- a/src/main/kotlin/com/hypto/iam/server/apis/PasscodeApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/PasscodeApi.kt
@@ -11,27 +11,54 @@ import com.hypto.iam.server.models.ResendInviteRequest
 import com.hypto.iam.server.models.VerifyEmailRequest
 import com.hypto.iam.server.security.UserPrincipal
 import com.hypto.iam.server.service.PasscodeService
+import com.hypto.iam.server.service.UsersService
+import com.hypto.iam.server.utils.HrnFactory
+import com.hypto.iam.server.utils.ResourceHrn
 import com.hypto.iam.server.validators.InviteMetadata
 import com.hypto.iam.server.validators.validate
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.auth.principal
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import org.koin.ktor.ext.inject
 
+@Suppress("ThrowsCount")
 fun Route.createPasscodeApi() {
     val passcodeService: PasscodeService by inject()
+    val usersService: UsersService by inject()
     val gson: Gson by inject()
 
     post("/verifyEmail") {
         val principal = context.principal<UserPrincipal>()
         val request = call.receive<VerifyEmailRequest>().validate()
-        val lowerCaseEmail = request.email.lowercase()
         // TODO: createuser permission checks needed for this endpoint if purpose is invite
         // TODO: add tests for invite user purpose
+        val email = if (request.email == null) {
+            request.userHrn?.let {
+                requireNotNull(principal) { "User is not authenticated. So can't send invite to ${request.userHrn}" }
+                val inviteeHrn = kotlin
+                    .runCatching { HrnFactory.getHrn(request.userHrn) as ResourceHrn }
+                    .getOrNull() ?: throw BadRequestException("Invalid user hrn")
+                val inviterHrn = HrnFactory.getHrn(principal.hrnStr) as ResourceHrn
+                require(inviterHrn.organization == inviteeHrn.organization) {
+                    "Authorization token doesn't belong to ${request.userHrn} organization"
+                }
+                // Adding a restriction to not allow sub organization users to send invites as we are not checking
+                // permissions for sending invites today.
+                // TODO: Add permission checks for sending invites
+                require(!inviterHrn.subOrganization.isNullOrEmpty()) {
+                    "Sub organization users can't send invites"
+                }
+                val inviteeUser = usersService.getUser(inviteeHrn)
+                inviteeUser.email ?: throw BadRequestException("UserHrn ${request.userHrn} doesn't have email")
+            } ?: throw BadRequestException("Email or userHrn is required")
+        } else {
+            request.email.lowercase()
+        }
 
         // Validations
         principal?.let {
@@ -48,7 +75,7 @@ fun Route.createPasscodeApi() {
         }
 
         val response = passcodeService.verifyEmail(
-            lowerCaseEmail,
+            email,
             request.purpose,
             request.organizationId,
             request.subOrganizationName,

--- a/src/main/kotlin/com/hypto/iam/server/apis/PasscodeApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/PasscodeApi.kt
@@ -50,7 +50,7 @@ fun Route.createPasscodeApi() {
                 // Adding a restriction to not allow sub organization users to send invites as we are not checking
                 // permissions for sending invites today.
                 // TODO: Add permission checks for sending invites
-                require(!inviterHrn.subOrganization.isNullOrEmpty()) {
+                require(inviterHrn.subOrganization.isNullOrEmpty()) {
                     "Sub organization users can't send invites"
                 }
                 val inviteeUser = usersService.getUser(inviteeHrn)
@@ -76,6 +76,7 @@ fun Route.createPasscodeApi() {
 
         val response = passcodeService.verifyEmail(
             email,
+            request.userHrn,
             request.purpose,
             request.organizationId,
             request.subOrganizationName,

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -11,6 +11,7 @@ import org.jooq.Condition
 import org.jooq.impl.DAOImpl
 import org.jooq.impl.DSL
 
+@Suppress("TooManyFunctions")
 object UserRepo : BaseRepo<UsersRecord, Users, String>() {
 
     private val idFun = fun(user: Users) = user.hrn
@@ -88,6 +89,16 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             .returning().fetchOne()
     }
 
+    suspend fun updateLoginAccessStatus(hrn: String, loginAccess: Boolean): UsersRecord? {
+        return ctx("users.updateLoginAccessStatus")
+            .update(USERS)
+            .set(USERS.UPDATED_AT, LocalDateTime.now())
+            .set(USERS.LOGIN_ACCESS, loginAccess)
+            .where(USERS.HRN.eq(hrn))
+            .and(USERS.DELETED.eq(false))
+            .returning().fetchOne()
+    }
+
     suspend fun delete(hrn: String): UsersRecord? = ctx("users.delete")
         .update(USERS)
         .set(USERS.UPDATED_AT, LocalDateTime.now())
@@ -104,9 +115,6 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             .and(USERS.VERIFIED.eq(true))
             .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } }
             .apply { organizationId?.let { and(USERS.ORGANIZATION_ID.eq(it)) } }
-//        if (!organizationId.isNullOrEmpty()) {
-//            builder = builder.and(USERS.ORGANIZATION_ID.eq(organizationId))
-//        }
         return builder.fetchOne()
     }
 

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -113,7 +113,11 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             .where(USERS.EMAIL.equalIgnoreCase(email))
             .and(USERS.DELETED.eq(false))
             .and(USERS.VERIFIED.eq(true))
-            .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } }
+            .apply {
+                subOrganizationName?.let {
+                    and(USERS.SUB_ORGANIZATION_NAME.eq(it))
+                } ?: and(USERS.SUB_ORGANIZATION_NAME.isNull)
+            }
             .apply { organizationId?.let { and(USERS.ORGANIZATION_ID.eq(it)) } }
         return builder.fetchOne()
     }

--- a/src/main/kotlin/com/hypto/iam/server/extensions/SubOrganizationUtils.kt
+++ b/src/main/kotlin/com/hypto/iam/server/extensions/SubOrganizationUtils.kt
@@ -1,0 +1,36 @@
+package com.hypto.iam.server.extensions
+
+import io.ktor.server.plugins.BadRequestException
+import java.util.Base64
+
+/**
+ * For sub organizations, we have to encode the email address to include the org and sub org id details in the email
+ * so that users can have unique credentials across orgs and sub orgs.
+ *
+ * To support this, we are using the email local addressing scheme. This scheme allows us to add a suffix to email
+ * address.
+ * Ex: hello@hypto.in can be encoded as hello+<base64(orgId:subOrgId)>@hypto.in
+ *
+ * With this option, same email address hello@hypto.in can coonfigure two different passwords for sub orgId1 and sub
+ * orgId2.
+ */
+fun getEncodedEmail(organizationId: String, subOrganizationName: String?, email: String) =
+    if (subOrganizationName != null) {
+        encodeSubOrgUserEmail(
+            email,
+            organizationId,
+            subOrganizationName
+        )
+    } else {
+        email
+    }
+
+private fun encodeSubOrgUserEmail(email: String, organizationId: String, subOrganizationName: String): String {
+    val emailParts = email.split("@").takeIf { it.size == 2 } ?: throw BadRequestException("Invalid email address")
+    val localPart = emailParts[0]
+    val domainPart = emailParts[1]
+    val subAddress = Base64.getEncoder().encodeToString(
+        "$organizationId:$subOrganizationName".toByteArray()
+    )
+    return "$localPart+$subAddress@$domainPart"
+}

--- a/src/main/kotlin/com/hypto/iam/server/idp/IdentityProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/idp/IdentityProvider.kt
@@ -60,8 +60,6 @@ data class User(
     val email: String,
     val loginAccess: Boolean,
     val isEnabled: Boolean,
-    val organizationId: String,
-    val subOrganizationId: String?,
     val createdBy: String,
     val verified: Boolean,
     val createdAt: String

--- a/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
@@ -13,6 +13,7 @@ import com.hypto.iam.server.db.tables.records.UsersRecord
 import com.hypto.iam.server.exceptions.EntityNotFoundException
 import com.hypto.iam.server.exceptions.InternalException
 import com.hypto.iam.server.extensions.PaginationContext
+import com.hypto.iam.server.extensions.getEncodedEmail
 import com.hypto.iam.server.extensions.toUTCOffset
 import com.hypto.iam.server.extensions.toUserStatus
 import com.hypto.iam.server.idp.IdentityGroup
@@ -95,13 +96,12 @@ class UsersServiceImpl : KoinComponent, UsersService {
             // we are using email sub-addressing where we will append the local part (before '@') with base64 value
             // of orgId:suborgId. By this way, the email address and password credentials will be uniquely stored in
             // the identity provider and later used for authentication.
-            val encodedEmail = email ?.let { getEmail(organizationId, subOrganizationName, email) }
             if (password != null && loginAccess) {
                 createUserInIdentityProvider(
                     username,
                     preferredUsername,
                     name,
-                    encodedEmail,
+                    email,
                     phoneNumber,
                     password,
                     organizationId,
@@ -129,13 +129,14 @@ class UsersServiceImpl : KoinComponent, UsersService {
                 }
             ) ?: throw InternalException("Unable to create user")
 
-            policies?.let {
+            if (policies != null && policies.isNotEmpty()) {
                 principalPolicyService.attachPoliciesToUser(
                     ResourceHrn(userHrn.toString()),
                     policies.map { hrnFactory.getHrn(it) }
                 )
             }
             if (password != null) {
+                val encodedEmail = email ?.let { getEncodedEmail(organizationId, subOrganizationName, it) }
                 encodedEmail?.let {
                     passcodeRepo.deleteByEmailAndPurpose(encodedEmail, VerifyEmailRequest.Purpose.invite)
                 }
@@ -160,7 +161,7 @@ class UsersServiceImpl : KoinComponent, UsersService {
         val org = organizationRepo.findById(organizationId)
             ?: throw EntityNotFoundException("Invalid organization id")
         val encodedEmail = email?.let {
-            getEmail(organizationId, subOrganizationName, email)
+            getEncodedEmail(organizationId, subOrganizationName, email)
         } ?: throw BadRequestException("Email is required")
 
         val passwordCredentials = PasswordCredentials(
@@ -196,16 +197,6 @@ class UsersServiceImpl : KoinComponent, UsersService {
         )
     }
 
-    private fun encodeSubOrgUserEmail(email: String, organizationId: String, subOrganizationName: String): String {
-        val emailParts = email.split("@").takeIf { it.size == 2 } ?: throw BadRequestException("Invalid email address")
-        val localPart = emailParts[0]
-        val domainPart = emailParts[1]
-        val subAddress = Base64.getEncoder().encodeToString(
-            "$organizationId:$subOrganizationName".toByteArray()
-        )
-        return "$localPart+$subAddress@$domainPart"
-    }
-
     override suspend fun getUser(organizationId: String, subOrganizationName: String?, userName: String): User {
         organizationRepo.findById(organizationId)
             ?: throw EntityNotFoundException("Invalid organization id. Unable to get user")
@@ -225,7 +216,7 @@ class UsersServiceImpl : KoinComponent, UsersService {
         subOrganizationName: String?,
         email: String
     ): User {
-        val userRecord = if (subOrganizationName == null && appConfig.app.uniqueUsersAcrossOrganizations) {
+        val userRecord = if (subOrganizationName.isNullOrEmpty() && appConfig.app.uniqueUsersAcrossOrganizations) {
             val user = userRepo.findByEmail(email)
                 ?: throw EntityNotFoundException("User with email - $email not found")
             organizationRepo.findById(user.organizationId)
@@ -456,24 +447,10 @@ class UsersServiceImpl : KoinComponent, UsersService {
         }
 
         val identityGroup = gson.fromJson(org.metadata.data(), IdentityGroup::class.java)
-        val encodedEmail = getEmail(organizationId, subOrganizationName, email)
+        val encodedEmail = getEncodedEmail(organizationId, subOrganizationName, email)
         identityProvider.authenticate(identityGroup, encodedEmail, password)
 
         return getUser(ResourceHrn(userRecord.hrn), userRecord)
-    }
-
-    private fun getEmail(
-        organizationId: String,
-        subOrganizationName: String?,
-        email: String,
-    ) = if (subOrganizationName != null) {
-        encodeSubOrgUserEmail(
-            email,
-            organizationId,
-            subOrganizationName
-        )
-    } else {
-        email
     }
 
     override suspend fun authenticate(

--- a/src/main/kotlin/com/hypto/iam/server/utils/Hrn.kt
+++ b/src/main/kotlin/com/hypto/iam/server/utils/Hrn.kt
@@ -30,7 +30,7 @@ abstract class Hrn {
 class ResourceHrn : Hrn {
     override val organization: String
     override val resource: String?
-    private val subOrganization: String?
+    val subOrganization: String?
     val resourceInstance: String?
 
     companion object {

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -10,6 +10,7 @@ import com.hypto.iam.server.extensions.TimeNature
 import com.hypto.iam.server.extensions.dateTime
 import com.hypto.iam.server.extensions.hrn
 import com.hypto.iam.server.extensions.noEndSpaces
+import com.hypto.iam.server.extensions.oneOf
 import com.hypto.iam.server.extensions.oneOrMoreOf
 import com.hypto.iam.server.extensions.validateAndThrowOnFailure
 import com.hypto.iam.server.models.ChangeUserPasswordRequest
@@ -165,6 +166,12 @@ fun ResetPasswordRequest.validate(): ResetPasswordRequest {
 
 fun VerifyEmailRequest.validate(): VerifyEmailRequest {
     verifyEmailRequestValidation.validateAndThrowOnFailure(this)
+    Validation {
+        (this::oneOf)(
+            this@validate,
+            listOf(VerifyEmailRequest::email, VerifyEmailRequest::userHrn)
+        )
+    }.validateAndThrowOnFailure(this)
 
     if (purpose == VerifyEmailRequest.Purpose.signup) {
         metadata?.let { validateSignupMetadata(metadata) }
@@ -482,6 +489,9 @@ val verifyEmailRequestValidation = Validation {
     }
     VerifyEmailRequest::organizationId ifPresent {
         run(organizationIdCheck)
+    }
+    VerifyEmailRequest::userHrn ifPresent {
+        run(hrnCheck)
     }
     VerifyEmailRequest::purpose required {}
 }

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -461,7 +461,6 @@ val createSubOrganizationRequest = Validation {
     CreateSubOrganizationRequest::name required {
         maxLength(MAX_SUB_ORG_LENGTH) hint "Maximum length supported for" +
             "name is $MAX_SUB_ORG_LENGTH characters"
-        noEndSpaces()
     }
     CreateSubOrganizationRequest::description ifPresent {
         run(descriptionCheck)
@@ -484,7 +483,7 @@ val createUserPasswordRequestValidation = Validation {
 }
 
 val verifyEmailRequestValidation = Validation {
-    VerifyEmailRequest::email required {
+    VerifyEmailRequest::email ifPresent {
         run(emailCheck)
     }
     VerifyEmailRequest::organizationId ifPresent {

--- a/src/test/kotlin/com/hypto/iam/server/helpers/DataSetupHelperV2.kt
+++ b/src/test/kotlin/com/hypto/iam/server/helpers/DataSetupHelperV2.kt
@@ -128,7 +128,8 @@ object DataSetupHelperV2 : AutoCloseKoinTest() {
         organizationId: String,
         subOrgId: String,
         bearerToken: String,
-        cognitoClient: CognitoIdentityProviderClient
+        cognitoClient: CognitoIdentityProviderClient,
+        loginAccess: Boolean = true,
     ): Pair<User, Credential> {
         val username = "testUserName" + IdGenerator.randomId()
         val email = "test-email" + IdGenerator.randomId() + "@hypto.in"
@@ -136,12 +137,12 @@ object DataSetupHelperV2 : AutoCloseKoinTest() {
         val createUserRequest = CreateUserRequest(
             preferredUsername = username,
             name = "lorem ipsum",
-            password = "testPassword@Hash1",
+            password = if (!loginAccess) null else "testPassword@Hash1",
             email = email,
             status = CreateUserRequest.Status.enabled,
             phone = phone,
             verified = true,
-            loginAccess = true
+            loginAccess = loginAccess
         )
 
         coEvery {

--- a/src/test/kotlin/com/hypto/iam/server/helpers/MockPasscodeRepo.kt
+++ b/src/test/kotlin/com/hypto/iam/server/helpers/MockPasscodeRepo.kt
@@ -18,6 +18,9 @@ fun KoinTest.mockPasscodeRepo(): PasscodeRepo {
             getValidPasscodeCount(any<String>(), any<VerifyEmailRequest.Purpose>())
         } returns 0
         coEvery {
+            getValidPasscodeCount(any<String>(), any<VerifyEmailRequest.Purpose>(), any<String>(), any<String>())
+        } returns 0
+        coEvery {
             getValidPasscodeById(
                 any<String>(),
                 any<VerifyEmailRequest.Purpose>(),


### PR DESCRIPTION
Changes
1. Support to create a user with no login access using "/users" API
2. Invite user to attach username/password credentials using "/verifyEmail" API
3. Create password for the invited user using "/create_password" API.

Test:
UTs added