### PR TITLE
:bug: fix: microsoft auth provider vulnerability

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -961,10 +961,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/user_name'
         - $ref: '#/components/parameters/organization_id'
-        - in: header
-          name: x-issuer
-          schema:
-            type: string
       requestBody:
         $ref: '#/components/requestBodies/AddUserAuthMethodRequest'
       responses:
@@ -2839,6 +2835,7 @@ components:
     AddUserAuthMethodRequest:
       summary: sample add user auth methods request
       value:
+        issuer: google
         token: <JWT token or Access token provided by the auth provider>
 
     CreateCredentialRequest:
@@ -3411,6 +3408,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        issuer:
+          type: string
         token:
           type: string
 

--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -952,6 +952,32 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
+    post:
+      tags:
+        - User Authorization Methods Management
+      summary: Add authorization methods to a user entity associated with the organization
+      description: Add authorization methods to a User
+      operationId: addUserAuthMethods
+      parameters:
+        - $ref: '#/components/parameters/user_name'
+        - $ref: '#/components/parameters/organization_id'
+      requestBody:
+        $ref: '#/components/requestBodies/AddUserAuthMethodRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/BaseSuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
 
   # credential
   /organizations/{organization_id}/users/{user_name}/credentials:
@@ -2152,6 +2178,17 @@ components:
             ResetPasswordRequest:
               $ref: '#/components/examples/ResetPasswordRequest'
 
+    AddUserAuthMethodRequest:
+      description: Payload to add user auth method
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AddUserAuthMethodRequest'
+          examples:
+            AddUserAuthMethodRequest:
+              $ref: '#/components/examples/AddUserAuthMethodRequest'
+
     CreateCredentialRequest:
       description: Payload to create credential
       required: true
@@ -2795,6 +2832,11 @@ components:
         email: bob@acme.com
         password: <new password>
 
+    AddUserAuthMethodRequest:
+      summary: sample add user auth methods request
+      value:
+        token: <JWT token or Access token provided by the auth provider>
+
     CreateCredentialRequest:
       summary: sample create credential request
       value:
@@ -3359,6 +3401,14 @@ components:
         password:
           type: string
           maxLength: 50
+
+    AddUserAuthMethodRequest:
+      description: Payload to add user auth methods
+      type: object
+      additionalProperties: false
+      properties:
+        token:
+          type: string
 
     CreateCredentialRequest:
       description: Payload to create credential

--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -955,12 +955,16 @@ paths:
     post:
       tags:
         - User Authorization Methods Management
-      summary: Add authorization methods to a user entity associated with the organization
-      description: Add authorization methods to a User
-      operationId: addUserAuthMethods
+      summary: Add authorization method to a user
+      description: Add authorization method to a user
+      operationId: addUserAuthMethod
       parameters:
         - $ref: '#/components/parameters/user_name'
         - $ref: '#/components/parameters/organization_id'
+        - in: header
+          name: x-issuer
+          schema:
+            type: string
       requestBody:
         $ref: '#/components/requestBodies/AddUserAuthMethodRequest'
       responses:

--- a/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/OrganizationApi.kt
@@ -49,6 +49,7 @@ fun Route.createOrganizationApi() {
                     name = oAuthUserPrincipal.name,
                     email = oAuthUserPrincipal.email,
                     issuer = oAuthUserPrincipal.issuer,
+                    metadata = oAuthUserPrincipal.metadata,
                 )
             call.respondText(
                 text = gson.toJson(CreateOrganizationResponse(organization, tokenResponse.token)),

--- a/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
@@ -1,17 +1,20 @@
 package com.hypto.iam.server.apis
 
 import com.google.gson.Gson
+import com.hypto.iam.server.authProviders.AuthProviderRegistry
 import com.hypto.iam.server.db.repositories.UserAuthRepo
 import com.hypto.iam.server.db.repositories.UserRepo
 import com.hypto.iam.server.di.getKoinInstance
 import com.hypto.iam.server.extensions.post
 import com.hypto.iam.server.models.GetDelegateTokenRequest
 import com.hypto.iam.server.models.TokenResponse
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.security.AuthenticationException
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenType
 import com.hypto.iam.server.security.UserPrincipal
 import com.hypto.iam.server.service.TokenService
+import com.hypto.iam.server.service.TokenServiceImpl
 import com.hypto.iam.server.utils.ResourceHrn
 import com.hypto.iam.server.validators.validate
 import io.ktor.http.ContentType
@@ -27,6 +30,7 @@ import io.ktor.server.routing.Route
 
 private val tokenService: TokenService = getKoinInstance()
 private val gson: Gson = getKoinInstance()
+private val userRepo = getKoinInstance<UserRepo>()
 private val userAuthRepo = getKoinInstance<UserAuthRepo>()
 
 @Suppress("ThrowsCount")
@@ -66,12 +70,30 @@ suspend fun generateTokenOauth(
 ) {
     val principal = context.principal<OAuthUserPrincipal>()!!
     val responseContentType = context.request.accept()
-    val user = UserRepo.findByEmail(principal.email) ?: throw AuthenticationException("User has not signed up yet")
-    val response = tokenService.generateJwtToken(ResourceHrn(user.hrn))
+    val user = userRepo.findByEmail(principal.email) ?: throw AuthenticationException("User has not signed up yet")
+    var userAuth = userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, principal.issuer)
 
-    if (userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, principal.issuer) == null) {
-        userAuthRepo.create(user.hrn, principal.issuer, null)
+    if (principal.issuer != TokenServiceImpl.ISSUER) {
+        val authProvider =
+            AuthProviderRegistry.getProvider(principal.issuer) ?: throw AuthenticationException(
+                "Invalid issuer",
+            )
+        if (authProvider.isVerifiedProvider && userAuth == null) {
+            userAuth =
+                userAuthRepo.create(
+                    user.hrn,
+                    principal.issuer,
+                    principal.metadata?.let { AuthMetadata.toJsonB(it) },
+                )
+        }
+        if (userAuth != null) {
+            authProvider.authenticate(principal, userAuth)
+        } else {
+            throw AuthenticationException("User has not signed up yet")
+        }
     }
+
+    val response = tokenService.generateJwtToken(ResourceHrn(user.hrn))
 
     when (responseContentType) {
         ContentType.Text.Plain.toString() ->

--- a/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/TokenApi.kt
@@ -86,11 +86,7 @@ suspend fun generateTokenOauth(
                     principal.metadata?.let { AuthMetadata.toJsonB(it) },
                 )
         }
-        if (userAuth != null) {
-            authProvider.authenticate(principal, userAuth)
-        } else {
-            throw AuthenticationException("User has not signed up yet")
-        }
+        userAuth?.let { authProvider.authenticate(principal, it) } ?: throw AuthenticationException("User has not signed up yet")
     }
 
     val response = tokenService.generateJwtToken(ResourceHrn(user.hrn))

--- a/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
@@ -46,9 +46,9 @@ fun Route.userAuthApi() {
         post("/organizations/{organization_id}/users/{id}/auth_methods") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["id"]!!
-            val issuer = call.request.headers["x-issuer"] ?: throw BadRequestException("Required headers are missing")
             val request = call.receive<AddUserAuthMethodRequest>().validate()
             val token = request.token ?: throw BadRequestException("token is missing")
+            val issuer = request.issuer ?: throw BadRequestException("issuer is missing")
             val principal = context.principal<UserPrincipal>()!!
             val response = userAuthService.createUserAuth(organizationId, userId, issuer, token, principal)
             call.respondText(

--- a/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
@@ -1,15 +1,20 @@
 package com.hypto.iam.server.apis
 
 import com.google.gson.Gson
+import com.hypto.iam.server.models.AddUserAuthMethodRequest
 import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.UserAuthService
+import com.hypto.iam.server.validators.validate
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import org.koin.ktor.ext.inject
 
 fun Route.userAuthApi() {
@@ -28,6 +33,25 @@ fun Route.userAuthApi() {
                 text = gson.toJson(response),
                 contentType = ContentType.Application.Json,
                 status = HttpStatusCode.OK,
+            )
+        }
+    }
+
+    withPermission(
+        "createUserAuth",
+        getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1),
+    ) {
+        post("/organizations/{organization_id}/users/{id}/auth_methods") {
+            val organizationId = call.parameters["organization_id"]!!
+            val userId = call.parameters["id"]!!
+            val issuer = call.request.headers["X-Issuer"] ?: throw BadRequestException("X-Issuer is missing")
+            val request = call.receive<AddUserAuthMethodRequest>().validate()
+            val token = request.token ?: throw BadRequestException("Token is missing")
+            val response = userAuthService.createUserAuth(organizationId, userId, issuer, token)
+            call.respondText(
+                text = gson.toJson(response),
+                contentType = ContentType.Application.Json,
+                status = HttpStatusCode.Created,
             )
         }
     }

--- a/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
@@ -40,13 +40,13 @@ fun Route.userAuthApi() {
     }
 
     withPermission(
-        "createUserAuth",
+        "addUserAuthMethod",
         getResourceHrnFunc(resourceNameIndex = 2, resourceInstanceIndex = 3, organizationIdIndex = 1),
     ) {
         post("/organizations/{organization_id}/users/{id}/auth_methods") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["id"]!!
-            val issuer = call.request.headers["x-issuer"] ?: throw BadRequestException("x-issuer header is missing")
+            val issuer = call.request.headers["x-issuer"] ?: throw BadRequestException("Required headers are missing")
             val request = call.receive<AddUserAuthMethodRequest>().validate()
             val token = request.token ?: throw BadRequestException("token is missing")
             val principal = context.principal<UserPrincipal>()!!

--- a/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
+++ b/src/main/kotlin/com/hypto/iam/server/apis/UserAuthApi.kt
@@ -2,6 +2,7 @@ package com.hypto.iam.server.apis
 
 import com.google.gson.Gson
 import com.hypto.iam.server.models.AddUserAuthMethodRequest
+import com.hypto.iam.server.security.UserPrincipal
 import com.hypto.iam.server.security.getResourceHrnFunc
 import com.hypto.iam.server.security.withPermission
 import com.hypto.iam.server.service.UserAuthService
@@ -9,6 +10,7 @@ import com.hypto.iam.server.validators.validate
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.auth.principal
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respondText
@@ -44,10 +46,11 @@ fun Route.userAuthApi() {
         post("/organizations/{organization_id}/users/{id}/auth_methods") {
             val organizationId = call.parameters["organization_id"]!!
             val userId = call.parameters["id"]!!
-            val issuer = call.request.headers["X-Issuer"] ?: throw BadRequestException("X-Issuer is missing")
+            val issuer = call.request.headers["x-issuer"] ?: throw BadRequestException("x-issuer header is missing")
             val request = call.receive<AddUserAuthMethodRequest>().validate()
-            val token = request.token ?: throw BadRequestException("Token is missing")
-            val response = userAuthService.createUserAuth(organizationId, userId, issuer, token)
+            val token = request.token ?: throw BadRequestException("token is missing")
+            val principal = context.principal<UserPrincipal>()!!
+            val response = userAuthService.createUserAuth(organizationId, userId, issuer, token, principal)
             call.respondText(
                 text = gson.toJson(response),
                 contentType = ContentType.Application.Json,

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/AuthProviderRegistry.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/AuthProviderRegistry.kt
@@ -11,6 +11,6 @@ object AuthProviderRegistry {
     fun getProvider(providerName: String) = providerRegistry[providerName]
 
     fun registerProvider(provider: BaseAuthProvider) {
-        providerRegistry = providerRegistry.plus(provider.getProviderName() to provider)
+        providerRegistry = providerRegistry.plus(provider.providerName to provider)
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -1,10 +1,18 @@
 package com.hypto.iam.server.authProviders
 
+import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
 
 interface BaseAuthProvider {
+    val isVerifiedProvider: Boolean
+
     fun getProviderName(): String
 
     fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
+
+    suspend fun authenticate(
+        principal: OAuthUserPrincipal,
+        userAuthRecord: UserAuthRecord,
+    )
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -4,15 +4,17 @@ import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
 
-interface BaseAuthProvider {
-    val isVerifiedProvider: Boolean
+abstract class BaseAuthProvider {
+    open val isVerifiedProvider: Boolean = true
 
-    fun getProviderName(): String
+    abstract fun getProviderName(): String
 
-    fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
+    abstract fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
 
-    suspend fun authenticate(
+    open suspend fun authenticate(
         principal: OAuthUserPrincipal,
         userAuthRecord: UserAuthRecord,
-    )
+    ) {
+        return
+    }
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/BaseAuthProvider.kt
@@ -4,11 +4,7 @@ import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.security.OAuthUserPrincipal
 import com.hypto.iam.server.security.TokenCredential
 
-abstract class BaseAuthProvider {
-    open val isVerifiedProvider: Boolean = true
-
-    abstract fun getProviderName(): String
-
+abstract class BaseAuthProvider(open val providerName: String, open val isVerifiedProvider: Boolean = true) {
     abstract fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal
 
     open suspend fun authenticate(

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -14,14 +14,12 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 
-object GoogleAuthProvider : BaseAuthProvider(), KoinComponent {
+object GoogleAuthProvider : BaseAuthProvider("google"), KoinComponent {
     private const val PROFILE_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     private const val ACCESS_TOKEN_KEY = "access_token"
 
     val gson: Gson by inject()
     private val httpClient: OkHttpClient by inject(named("AuthProvider"))
-
-    override fun getProviderName() = "google"
 
     override fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal {
         val requestBuilder =
@@ -45,7 +43,7 @@ object GoogleAuthProvider : BaseAuthProvider(), KoinComponent {
             googleUser.email,
             googleUser.name,
             googleUser.hd ?: "",
-            getProviderName(),
+            this.providerName,
         )
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -2,7 +2,6 @@ package com.hypto.iam.server.authProviders
 
 import com.google.gson.Gson
 import com.hypto.iam.server.ROOT_ORG
-import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.logger
 import com.hypto.iam.server.security.AuthenticationException
@@ -15,13 +14,12 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 
-object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
+object GoogleAuthProvider : BaseAuthProvider(), KoinComponent {
     private const val PROFILE_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     private const val ACCESS_TOKEN_KEY = "access_token"
 
     val gson: Gson by inject()
     private val httpClient: OkHttpClient by inject(named("AuthProvider"))
-    override val isVerifiedProvider: Boolean = true
 
     override fun getProviderName() = "google"
 
@@ -49,13 +47,6 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
             googleUser.hd ?: "",
             getProviderName(),
         )
-    }
-
-    override suspend fun authenticate(
-        principal: OAuthUserPrincipal,
-        userAuthRecord: UserAuthRecord,
-    ) {
-        return
     }
 }
 

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/GoogleAuthProvider.kt
@@ -2,6 +2,7 @@ package com.hypto.iam.server.authProviders
 
 import com.google.gson.Gson
 import com.hypto.iam.server.ROOT_ORG
+import com.hypto.iam.server.db.tables.records.UserAuthRecord
 import com.hypto.iam.server.exceptions.UnknownException
 import com.hypto.iam.server.logger
 import com.hypto.iam.server.security.AuthenticationException
@@ -20,6 +21,7 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
 
     val gson: Gson by inject()
     private val httpClient: OkHttpClient by inject(named("AuthProvider"))
+    override val isVerifiedProvider: Boolean = true
 
     override fun getProviderName() = "google"
 
@@ -47,6 +49,13 @@ object GoogleAuthProvider : BaseAuthProvider, KoinComponent {
             googleUser.hd ?: "",
             getProviderName(),
         )
+    }
+
+    override suspend fun authenticate(
+        principal: OAuthUserPrincipal,
+        userAuthRecord: UserAuthRecord,
+    ) {
+        return
     }
 }
 

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -16,14 +16,11 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 
-object MicrosoftAuthProvider : BaseAuthProvider(), KoinComponent {
+object MicrosoftAuthProvider : BaseAuthProvider("microsoft", false), KoinComponent {
     private const val PROFILE_URL = "https://graph.microsoft.com/v1.0/me"
 
     val gson: Gson by inject()
     private val httpClient: OkHttpClient by inject(named("AuthProvider"))
-    override val isVerifiedProvider: Boolean = false
-
-    override fun getProviderName() = "microsoft"
 
     override fun getProfileDetails(tokenCredential: TokenCredential): OAuthUserPrincipal {
         val requestBuilder =
@@ -51,7 +48,7 @@ object MicrosoftAuthProvider : BaseAuthProvider(), KoinComponent {
             microsoftUser.mail,
             microsoftUser.displayName,
             "",
-            getProviderName(),
+            this.providerName,
             AuthMetadata(
                 id = microsoftUser.id,
             ),

--- a/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/MicrosoftAuthProvider.kt
@@ -16,7 +16,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 
-object MicrosoftAuthProvider : BaseAuthProvider, KoinComponent {
+object MicrosoftAuthProvider : BaseAuthProvider(), KoinComponent {
     private const val PROFILE_URL = "https://graph.microsoft.com/v1.0/me"
 
     val gson: Gson by inject()

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -331,16 +331,10 @@ data class AuthMetadata(
     val id: String? = null,
 ) {
     companion object {
-        fun from(json: String): AuthMetadata {
-            return gson.fromJson(json, AuthMetadata::class.java)
-        }
+        fun from(json: String): AuthMetadata = gson.fromJson(json, AuthMetadata::class.java)
 
-        fun from(json: JSONB): AuthMetadata {
-            return gson.fromJson(json.data(), AuthMetadata::class.java)
-        }
+        fun from(json: JSONB): AuthMetadata = gson.fromJson(json.data(), AuthMetadata::class.java)
 
-        fun toJsonB(authMetadata: AuthMetadata): JSONB {
-            return JSONB.valueOf(gson.toJson(authMetadata))
-        }
+        fun toJsonB(authMetadata: AuthMetadata) = JSONB.valueOf(gson.toJson(authMetadata))
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
+++ b/src/main/kotlin/com/hypto/iam/server/security/Authentication.kt
@@ -27,6 +27,7 @@ import io.ktor.server.auth.UnauthorizedResponse
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.response.respond
 import mu.KotlinLogging
+import org.jooq.JSONB
 import java.util.Base64
 
 private val logger = KotlinLogging.logger { }
@@ -85,6 +86,7 @@ data class OAuthUserPrincipal(
     val name: String,
     val companyName: String,
     override val issuer: String,
+    val metadata: AuthMetadata? = null,
 ) : IamPrincipal
 
 class TokenAuthenticationProvider internal constructor(
@@ -321,6 +323,24 @@ fun bearerAuthValidation(
             }
         } catch (e: Exception) {
             null
+        }
+    }
+}
+
+data class AuthMetadata(
+    val id: String? = null,
+) {
+    companion object {
+        fun from(json: String): AuthMetadata {
+            return gson.fromJson(json, AuthMetadata::class.java)
+        }
+
+        fun from(json: JSONB): AuthMetadata {
+            return gson.fromJson(json.data(), AuthMetadata::class.java)
+        }
+
+        fun toJsonB(authMetadata: AuthMetadata): JSONB {
+            return JSONB.valueOf(gson.toJson(authMetadata))
         }
     }
 }

--- a/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/OrganizationsService.kt
@@ -19,6 +19,7 @@ import com.hypto.iam.server.models.CreateOrganizationRequest
 import com.hypto.iam.server.models.Organization
 import com.hypto.iam.server.models.TokenResponse
 import com.hypto.iam.server.models.VerifyEmailRequest
+import com.hypto.iam.server.security.AuthMetadata
 import com.hypto.iam.server.utils.ApplicationIdUtil
 import com.hypto.iam.server.utils.HrnFactory
 import com.hypto.iam.server.utils.IamResources
@@ -149,6 +150,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
         name: String,
         email: String,
         issuer: String,
+        metadata: AuthMetadata?,
     ): Pair<Organization, TokenResponse> {
         val organizationId = idGenerator.organizationId()
         val username = idGenerator.username()
@@ -215,7 +217,7 @@ class OrganizationsServiceImpl : KoinComponent, OrganizationsService {
                 userAuthRepo.create(
                     hrn = userHrn.toString(),
                     providerName = issuer,
-                    authMetadata = null,
+                    authMetadata = metadata?.let { AuthMetadata.toJsonB(it) },
                 )
 
                 return@wrap Pair(organization, token)
@@ -317,6 +319,7 @@ interface OrganizationsService {
         name: String,
         email: String,
         issuer: String,
+        metadata: AuthMetadata? = null,
     ): Pair<Organization, TokenResponse>
 
     suspend fun getOrganization(id: String): Organization

--- a/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
@@ -1,10 +1,17 @@
 package com.hypto.iam.server.service
 
+import com.hypto.iam.server.authProviders.AuthProviderRegistry
 import com.hypto.iam.server.db.repositories.OrganizationRepo
 import com.hypto.iam.server.db.repositories.UserAuthRepo
+import com.hypto.iam.server.db.repositories.UserRepo
 import com.hypto.iam.server.exceptions.EntityNotFoundException
+import com.hypto.iam.server.models.BaseSuccessResponse
 import com.hypto.iam.server.models.UserAuthMethod
 import com.hypto.iam.server.models.UserAuthMethodsResponse
+import com.hypto.iam.server.security.AuthMetadata
+import com.hypto.iam.server.security.AuthenticationException
+import com.hypto.iam.server.security.TokenCredential
+import com.hypto.iam.server.security.TokenType
 import com.hypto.iam.server.utils.IamResources
 import com.hypto.iam.server.utils.ResourceHrn
 import org.koin.core.component.KoinComponent
@@ -12,7 +19,38 @@ import org.koin.core.component.inject
 
 class UserAuthServiceImpl : KoinComponent, UserAuthService {
     private val organizationRepo: OrganizationRepo by inject()
+    private val userRepo: UserRepo by inject()
     private val userAuthRepo: UserAuthRepo by inject()
+
+    override suspend fun createUserAuth(
+        organizationId: String,
+        userId: String,
+        issuer: String,
+        token: String,
+    ): BaseSuccessResponse {
+        if (issuer != TokenServiceImpl.ISSUER) {
+            val authProvider =
+                AuthProviderRegistry.getProvider(issuer) ?: throw AuthenticationException(
+                    "Invalid issuer",
+                )
+            val oAuthUserPrincipal = authProvider.getProfileDetails(TokenCredential(token, TokenType.OAUTH))
+            val user =
+                userRepo.findByEmail(oAuthUserPrincipal.email) ?: throw AuthenticationException(
+                    "User has not signed up yet",
+                )
+            val userAuth = userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, issuer)
+            if (userAuth != null) {
+                userAuthRepo.create(
+                    user.hrn,
+                    oAuthUserPrincipal.issuer,
+                    oAuthUserPrincipal.metadata?.let { AuthMetadata.toJsonB(it) },
+                )
+            } else {
+                throw AuthenticationException("User already has this auth method")
+            }
+        }
+        return BaseSuccessResponse(true)
+    }
 
     override suspend fun listUserAuth(
         organizationId: String,
@@ -34,6 +72,13 @@ class UserAuthServiceImpl : KoinComponent, UserAuthService {
 }
 
 interface UserAuthService {
+    suspend fun createUserAuth(
+        organizationId: String,
+        userId: String,
+        issuer: String,
+        token: String,
+    ): BaseSuccessResponse
+
     suspend fun listUserAuth(
         organizationId: String,
         userHrn: String,

--- a/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UserAuthService.kt
@@ -9,7 +9,6 @@ import com.hypto.iam.server.models.BaseSuccessResponse
 import com.hypto.iam.server.models.UserAuthMethod
 import com.hypto.iam.server.models.UserAuthMethodsResponse
 import com.hypto.iam.server.security.AuthMetadata
-import com.hypto.iam.server.security.AuthenticationException
 import com.hypto.iam.server.security.TokenCredential
 import com.hypto.iam.server.security.TokenType
 import com.hypto.iam.server.security.UserPrincipal
@@ -55,7 +54,7 @@ class UserAuthServiceImpl : KoinComponent, UserAuthService {
         userId: String,
     ): UserAuthMethodsResponse {
         organizationRepo.findById(organizationId)
-            ?: throw EntityNotFoundException("Invalid organization id name. Unable to get user")
+            ?: throw EntityNotFoundException("Invalid organization id")
         val userAuth =
             userAuthRepo.fetchUserAuth(
                 ResourceHrn(organizationId, "", IamResources.USER, userId),

--- a/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
@@ -316,7 +316,7 @@ class UsersServiceImpl : KoinComponent, UsersService {
         val user = getUser(organizationId, subOrganizationName, userId)
         val cognito = appConfig.cognito
         organizationRepo.findById(organizationId)
-            ?: throw EntityNotFoundException("Invalid organization id name. Unable to create user")
+            ?: throw EntityNotFoundException("Invalid organization id")
         if (userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, TokenServiceImpl.ISSUER) != null) {
             throw BadRequestException("Organization already has password access")
         }

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -363,6 +363,7 @@ val updateOrganizationRequestValidation =
 val addUserAuthMethodRequestValidation =
     Validation {
         AddUserAuthMethodRequest::token required {}
+        AddUserAuthMethodRequest::issuer required {}
     }
 
 val createCredentialRequestValidation =

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -13,6 +13,7 @@ import com.hypto.iam.server.extensions.noEndSpaces
 import com.hypto.iam.server.extensions.oneOf
 import com.hypto.iam.server.extensions.oneOrMoreOf
 import com.hypto.iam.server.extensions.validateAndThrowOnFailure
+import com.hypto.iam.server.models.AddUserAuthMethodRequest
 import com.hypto.iam.server.models.ChangeUserPasswordRequest
 import com.hypto.iam.server.models.CreateActionRequest
 import com.hypto.iam.server.models.CreateCredentialRequest
@@ -60,6 +61,13 @@ fun CreateOrganizationRequest.validate(): CreateOrganizationRequest {
  */
 fun UpdateOrganizationRequest.validate(): UpdateOrganizationRequest {
     return updateOrganizationRequestValidation.validateAndThrowOnFailure(this)
+}
+
+/**
+ * Extension function to validate AddUserAuthMethodRequest input from client
+ */
+fun AddUserAuthMethodRequest.validate(): AddUserAuthMethodRequest {
+    return addUserAuthMethodRequestValidation.validateAndThrowOnFailure(this)
 }
 
 /**
@@ -350,6 +358,11 @@ val updateOrganizationRequestValidation =
         UpdateOrganizationRequest::description ifPresent {
             run(descriptionCheck)
         }
+    }
+
+val addUserAuthMethodRequestValidation =
+    Validation {
+        AddUserAuthMethodRequest::token required {}
     }
 
 val createCredentialRequestValidation =

--- a/src/test/kotlin/com/hypto/iam/server/apis/UserAuthApiTest.kt
+++ b/src/test/kotlin/com/hypto/iam/server/apis/UserAuthApiTest.kt
@@ -1,0 +1,206 @@
+package com.hypto.iam.server.apis
+
+import com.google.gson.Gson
+import com.hypto.iam.server.ROOT_ORG
+import com.hypto.iam.server.authProviders.MicrosoftAuthProvider
+import com.hypto.iam.server.helpers.AbstractContainerBaseTest
+import com.hypto.iam.server.helpers.DataSetupHelperV2.createOrganization
+import com.hypto.iam.server.models.AddUserAuthMethodRequest
+import com.hypto.iam.server.models.UserAuthMethodsResponse
+import com.hypto.iam.server.security.AuthMetadata
+import com.hypto.iam.server.security.OAuthUserPrincipal
+import com.hypto.iam.server.security.TokenCredential
+import com.hypto.iam.server.security.TokenType
+import com.hypto.iam.server.service.TokenServiceImpl
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.koin.core.component.inject
+import java.util.UUID
+
+class UserAuthApiTest : AbstractContainerBaseTest() {
+    val gson: Gson by inject()
+
+    @Test
+    fun `List auth methods`() {
+        testApplication {
+            // Arrange
+            environment {
+                config = ApplicationConfig("application-custom.conf")
+            }
+            val (createdOrganization, createdUser) = createOrganization()
+
+            // Act
+            val orgId = createdOrganization.organization.id
+            val userId =
+                createdOrganization.organization.rootUser.hrn.substring(
+                    createdOrganization.organization.rootUser.hrn.lastIndexOf("/") + 1,
+                )
+            val response =
+                client.get("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                }
+            val userAuthMethodsResponse = gson.fromJson(response.bodyAsText(), UserAuthMethodsResponse::class.java)
+
+            // Assert
+            Assertions.assertEquals(HttpStatusCode.OK, response.status)
+            userAuthMethodsResponse.data?.let { Assertions.assertEquals(1, it.size) }
+            userAuthMethodsResponse.data?.let { Assertions.assertEquals(TokenServiceImpl.ISSUER, it[0].providerName) }
+        }
+    }
+
+    @Test
+    fun `Add auth methods microsoft`() {
+        testApplication {
+            // Arrange
+            environment {
+                config = ApplicationConfig("application-custom.conf")
+            }
+            val (createdOrganization, createdUser) = createOrganization()
+            val orgId = createdOrganization.organization.id
+            val userId =
+                createdOrganization.organization.rootUser.hrn.substring(
+                    createdOrganization.organization.rootUser.hrn.lastIndexOf("/") + 1,
+                )
+            val microsoftToken = "test-microsoft-token"
+            val id = UUID.randomUUID().toString()
+
+            mockkObject(MicrosoftAuthProvider)
+            coEvery {
+                MicrosoftAuthProvider.getProfileDetails(any())
+            } coAnswers {
+                OAuthUserPrincipal(
+                    tokenCredential = TokenCredential(microsoftToken, TokenType.OAUTH),
+                    companyName = createdOrganization.organization.name,
+                    name = createdUser.name ?: "",
+                    email = createdUser.email,
+                    organization = ROOT_ORG,
+                    issuer = "microsoft",
+                    metadata = AuthMetadata(id = id),
+                )
+            }
+
+            // Act
+            val addAuthMethodsResponse =
+                client.post("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.ContentType, "application/json")
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                    setBody(
+                        gson.toJson(
+                            AddUserAuthMethodRequest(
+                                issuer = "microsoft",
+                                token = microsoftToken,
+                            ),
+                        ),
+                    )
+                }
+            val listAuthMethodsResponse =
+                client.get("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                }
+            val userAuthMethodsResponse = gson.fromJson(listAuthMethodsResponse.bodyAsText(), UserAuthMethodsResponse::class.java)
+
+            // Assert
+            Assertions.assertEquals(HttpStatusCode.Created, addAuthMethodsResponse.status)
+            Assertions.assertEquals(HttpStatusCode.OK, listAuthMethodsResponse.status)
+            userAuthMethodsResponse.data?.let { Assertions.assertEquals(2, it.size) }
+            userAuthMethodsResponse.data?.let { Assertions.assertEquals(TokenServiceImpl.ISSUER, it[0].providerName) }
+            userAuthMethodsResponse.data?.let { Assertions.assertEquals("microsoft", it[1].providerName) }
+
+            val loginResponse =
+                client.post("/login") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header("x-issuer", "microsoft")
+                    header(HttpHeaders.Authorization, "Bearer $microsoftToken")
+                }
+            Assertions.assertEquals(HttpStatusCode.OK, loginResponse.status)
+        }
+    }
+
+    @Test
+    fun `Add auth methods - failure`() {
+        testApplication {
+            // Arrange
+            environment {
+                config = ApplicationConfig("application-custom.conf")
+            }
+            val (createdOrganization, createdUser) = createOrganization()
+            val orgId = createdOrganization.organization.id
+            val userId =
+                createdOrganization.organization.rootUser.hrn.substring(
+                    createdOrganization.organization.rootUser.hrn.lastIndexOf("/") + 1,
+                )
+            val microsoftToken = "test-microsoft-token"
+
+            mockkObject(MicrosoftAuthProvider)
+            coEvery {
+                MicrosoftAuthProvider.getProfileDetails(any())
+            } coAnswers {
+                OAuthUserPrincipal(
+                    tokenCredential = TokenCredential(microsoftToken, TokenType.OAUTH),
+                    companyName = createdOrganization.organization.name,
+                    name = createdUser.name ?: "",
+                    email = createdUser.email,
+                    organization = ROOT_ORG,
+                    issuer = "microsoft",
+                    metadata = AuthMetadata(id = UUID.randomUUID().toString()),
+                )
+            }
+
+            // Act
+            val addAuthMethodsResponse1 =
+                client.post("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.ContentType, "application/json")
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                    setBody(
+                        gson.toJson(
+                            AddUserAuthMethodRequest(
+                                issuer = "microsoft",
+                            ),
+                        ),
+                    )
+                }
+            val addAuthMethodsResponse2 =
+                client.post("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.ContentType, "application/json")
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                    setBody(
+                        gson.toJson(
+                            AddUserAuthMethodRequest(
+                                token = microsoftToken,
+                            ),
+                        ),
+                    )
+                }
+            val addAuthMethodsResponse3 =
+                client.post("/organizations/$orgId/users/$userId/auth_methods") {
+                    header(HttpHeaders.ContentType, "application/json")
+                    header(HttpHeaders.Authorization, "Bearer ${createdOrganization.rootUserToken}")
+                    setBody(
+                        gson.toJson(
+                            AddUserAuthMethodRequest(
+                                issuer = "msft",
+                                token = microsoftToken,
+                            ),
+                        ),
+                    )
+                }
+
+            // Assert
+            Assertions.assertEquals(HttpStatusCode.BadRequest, addAuthMethodsResponse1.status)
+            Assertions.assertEquals(HttpStatusCode.BadRequest, addAuthMethodsResponse2.status)
+            Assertions.assertEquals(HttpStatusCode.BadRequest, addAuthMethodsResponse3.status)
+        }
+    }
+}


### PR DESCRIPTION
### Problem
- Account takeover due to misconfigured Microsoft Azure Active Directory Attribute

### Solution
- Store `oid` in `auth_metadata` column of `iam.user_auth` table
- **Explanation of prevention of attack:** Say the victim’s email is configured against the hacker’s mail in Azure Active Directory, but the `oid` of the hacker’s Microsoft account will not match the `oid` of the victim, thereby denying access.

### Tests
- Tested manually in local dev environment