### PR TITLE
Avoid sub organization users/invites on org api requests

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/PasscodeRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/PasscodeRepo.kt
@@ -48,7 +48,7 @@ object PasscodeRepo : BaseRepo<PasscodesRecord, Passcodes, String>() {
             .apply {
                 subOrganizationName?.let {
                     and(PASSCODES.SUB_ORGANIZATION_NAME.eq(subOrganizationName))
-                }
+                } ?: and(PASSCODES.SUB_ORGANIZATION_NAME.isNull)
             }
             .fetchOne(0, Int::class.java) ?: 0
 
@@ -92,7 +92,7 @@ object PasscodeRepo : BaseRepo<PasscodesRecord, Passcodes, String>() {
             .apply {
                 subOrganizationName?.let {
                     and(PASSCODES.SUB_ORGANIZATION_NAME.eq(subOrganizationName))
-                }
+                } ?: and(PASSCODES.SUB_ORGANIZATION_NAME.isNull)
             }
             .fetchOne()
     }
@@ -114,7 +114,7 @@ object PasscodeRepo : BaseRepo<PasscodesRecord, Passcodes, String>() {
             .apply {
                 subOrganizationName?.let {
                     and(PASSCODES.SUB_ORGANIZATION_NAME.eq(subOrganizationName))
-                }
+                } ?: and(PASSCODES.SUB_ORGANIZATION_NAME.isNull)
             }
             .and(PASSCODES.VALID_UNTIL.ge(LocalDateTime.now()))
             .paginate(PASSCODES.CREATED_AT, paginationContext)

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -80,7 +80,7 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             } else {
                 // Check all verified and unverified users within the organization
                 builder.and(USERS.ORGANIZATION_ID.eq(organizationId))
-                    .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } ?: and(USERS.SUB_ORGANIZATION_NAME.isNull)}
+                    .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } ?: and(USERS.SUB_ORGANIZATION_NAME.isNull) }
             }
 
         return ctx("users.existsByAliasUsername").fetchExists(builder)

--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -36,7 +36,11 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
     ): List<UsersRecord> {
         return ctx("users.fetchMany").selectFrom(USERS)
             .where(USERS.ORGANIZATION_ID.eq(organizationId))
-            .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } }
+            .apply {
+                subOrganizationName?.let {
+                    and(USERS.SUB_ORGANIZATION_NAME.eq(it))
+                } ?: and(USERS.SUB_ORGANIZATION_NAME.isNull)
+            }
             .and(USERS.DELETED.eq(false))
             .paginate(USERS.CREATED_AT, paginationContext)
             .fetch()
@@ -76,7 +80,7 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
             } else {
                 // Check all verified and unverified users within the organization
                 builder.and(USERS.ORGANIZATION_ID.eq(organizationId))
-                    .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } }
+                    .apply { subOrganizationName?.let { and(USERS.SUB_ORGANIZATION_NAME.eq(it)) } ?: and(USERS.SUB_ORGANIZATION_NAME.isNull)}
             }
 
         return ctx("users.existsByAliasUsername").fetchExists(builder)


### PR DESCRIPTION
Desc
Currently the list queries in user & passcode repos return sub org users even if the request was made for an org.  Changed to return sub org users only when sub org APIs are requested