### PR TITLE
Cognito user pool was incorrectly updated during password create

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/UsersService.kt
@@ -42,7 +42,6 @@ class UsersServiceImpl : KoinComponent, UsersService {
     private val hrnFactory: HrnFactory by inject()
     private val userRepo: UserRepo by inject()
     private val organizationRepo: OrganizationRepo by inject()
-    private val organizationService: OrganizationsService by inject()
     private val identityProvider: IdentityProvider by inject()
     private val gson: Gson by inject()
     private val txMan: TxMan by inject()
@@ -331,13 +330,11 @@ class UsersServiceImpl : KoinComponent, UsersService {
         password: String,
     ): BaseSuccessResponse {
         val user = getUser(organizationId, subOrganizationName, userId)
-        val cognito = appConfig.cognito
         organizationRepo.findById(organizationId)
             ?: throw EntityNotFoundException("Invalid organization id")
         if (userAuthRepo.fetchByUserHrnAndProviderName(user.hrn, TokenServiceImpl.ISSUER) != null) {
             throw BadRequestException("Organization already has password access")
         }
-        organizationService.updateOrganization(organizationId, null, null, cognito)
         createUserInIdentityProvider(
             user.username,
             user.preferredUsername,


### PR DESCRIPTION
Desc:
During user password creation, incorrectly updating the cognito user pool of the org, this was impacting existing user's login. This was a redundant org update, so removed this update.